### PR TITLE
Add per-issue revision retry limit

### DIFF
--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -71,7 +71,7 @@ Count prior revision attempts by looking for "## Revision Summary" comments alre
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 # gh pr comment posts to the issues API endpoint, so count there
-REVISION_COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq '[.[] | select(.body | test("## Revision Summary"))] | length' 2>/dev/null || echo 0)
+REVISION_COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate 2>/dev/null | jq -s 'add | map(select(.body | test("^## Revision Summary"))) | length' || echo 0)
 MAX_REVISIONS=3
 ```
 


### PR DESCRIPTION
## Summary

- Adds Step 2.5 to `/revise` skill that counts prior "Revision Summary" comments on the PR before attempting another revision
- After 3 revision attempts, escalates to `agent:needs-human` instead of retrying — prevents infinite loops when PR feedback doesn't converge
- Uses the issues API endpoint (where `gh pr comment` posts) to count revision summaries
- Check happens before claiming the issue, so no unnecessary label churn

## Test plan

- [ ] Verify a PR with 0-2 prior revision summaries proceeds to Step 3 normally
- [ ] Verify a PR with 3+ prior revision summaries triggers escalation (`agent:needs-human` label + comment)
- [ ] Verify the escalation comment includes correct revision count and PR number

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)