### PR TITLE
Add per-build timeout within sessions

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -73,7 +73,7 @@ If the timeout is reached mid-build, commit work-in-progress and escalate:
 ```bash
 git add <files modified so far>
 git commit -m "wip: timeout after ${ELAPSED}s on issue #${ISSUE}" || true
-git push -u origin $BRANCH 2>/dev/null || true
+git push -u origin HEAD 2>/dev/null || true
 gh issue edit $ISSUE --remove-label "agent:in-progress" --add-label "agent:needs-human"
 sleep 1
 gh issue comment $ISSUE --body "$(cat <<TIMEOUT


### PR DESCRIPTION
## Summary

- Adds Step 3.5 to `/build` skill that records build start time and sets a 30-minute per-build timeout
- Before each major step (6, 6b, 6c, 7, 8), the agent checks elapsed time
- On timeout: commits WIP, pushes branch, labels `agent:needs-human`, posts escalation comment
- Prevents a single hung build from consuming the entire session allocation

## Test plan

- [ ] Verify build start time is recorded after claiming the issue
- [ ] Verify timeout check template is clear enough for the agent to apply at each step
- [ ] Verify WIP commit + escalation flow uses correct labels and includes `sleep 1` after mutations

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)