### PR TITLE
Add runtime circular dependency detection to /sync

### DIFF
--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -84,17 +84,24 @@ sleep 1
 **Circular dependency detection:** After processing blocked issues above, if ALL remaining open issues are still labeled `agent:blocked` (none were promoted to `agent:ready`), check for dependency cycles. Extract the dependency graph from issue bodies:
 
 ```bash
-# Build dependency edges for tsort
+# Only run cycle detection if all open issues are blocked
 BLOCKED_ISSUES=$(echo "$OPEN_ISSUES" | jq -r '[.[] | select(.labels | map(.name) | index("agent:blocked"))] | .[].number')
+BLOCKED_COUNT=$(printf '%s\n' $BLOCKED_ISSUES | sed '/^$/d' | wc -l | tr -d ' ')
+OPEN_COUNT=$(echo "$OPEN_ISSUES" | jq 'length')
 
-EDGES=""
-for ISSUE_NUM in $BLOCKED_ISSUES; do
-  # Extract dependencies only from the "## Dependencies" section to avoid false edges
-  DEPS=$(echo "$OPEN_ISSUES" | jq -r ".[] | select(.number == $ISSUE_NUM) | .body" | sed -n '/^## Dependencies/,/^##/p' | grep -oE '#[0-9]+' | tr -d '#' | sort -u)
-  for DEP in $DEPS; do
-    EDGES="${EDGES}${DEP} ${ISSUE_NUM}\n"
+if [ "$OPEN_COUNT" -gt 0 ] && [ "$OPEN_COUNT" -eq "$BLOCKED_COUNT" ]; then
+  # Build dependency edges for tsort — only include edges between blocked issues
+  EDGES=""
+  for ISSUE_NUM in $BLOCKED_ISSUES; do
+    # Extract dependencies only from the "## Dependencies" section to avoid false edges
+    RAW_DEPS=$(echo "$OPEN_ISSUES" | jq -r ".[] | select(.number == $ISSUE_NUM) | .body" | sed -n '/^## Dependencies/,/^##/p' | grep -oE '#[0-9]+' | tr -d '#')
+    # Intersect with blocked issues so the graph only includes open blocked issues
+    DEPS=$(comm -12 <(printf '%s\n' $RAW_DEPS | sort -u) <(printf '%s\n' $BLOCKED_ISSUES | sort -u))
+    for DEP in $DEPS; do
+      EDGES="${EDGES}${DEP} ${ISSUE_NUM}\n"
+    done
   done
-done
+fi
 ```
 
 Detect cycles using `tsort` (available on macOS and Linux). `tsort` prints cycle members to stderr:
@@ -110,13 +117,13 @@ fi
 If a cycle is found:
 1. Identify the cycle members (e.g., A → B → C → A)
 2. Find the lowest-priority issue in the cycle (by `priority:*` label — low < medium < high)
-3. Remove that issue's blocking dependency by posting a comment explaining the cycle was broken
-4. Relabel the unblocked issue as `agent:ready`:
+3. Relabel the unblocked issue as `agent:ready`
+4. Post a comment explaining the cycle was broken:
 
 ```bash
 gh issue edit {UNBLOCKED} --remove-label "agent:blocked" --add-label "agent:ready"
 sleep 1
-gh issue comment {UNBLOCKED} --body "$(cat <<CYCLE
+gh issue comment {UNBLOCKED} --body "$(cat <<'CYCLE'
 ## Circular Dependency Detected
 
 A dependency cycle was found: {cycle description, e.g., #3 → #5 → #7 → #3}
@@ -239,4 +246,4 @@ Next action: {one of the following}
 
 ## Output only
 
-This skill produces output. It does not modify any code or create any files. It only reads GitHub state and relabels issues when needed: promoting blocked issues whose dependencies are met, recovering stale in-progress issues, classifying triage issues, and resetting stuck done issues.
+This skill produces output. It does not modify any code or create any files. It only reads GitHub state and relabels issues when needed: promoting blocked issues whose dependencies are met, recovering stale in-progress issues, classifying triage issues, resetting stuck done issues, and breaking dependency cycles (with an explanatory comment posted on the affected issue).


### PR DESCRIPTION
## Summary

- Adds cycle detection to `/sync` that triggers when all remaining open issues are `agent:blocked`
- Builds dependency graph from issue bodies using already-fetched `$OPEN_ISSUES` data (zero extra API calls for detection)
- Breaks cycles by removing the dependency from the lowest-priority issue, relabeling it `agent:ready`
- Posts an explanatory comment documenting the cycle and why the dependency was dropped
- Falls back to human review if all issues are blocked but no cycle is detected

## Test plan

- [ ] Verify cycle detection only triggers when ALL remaining issues are blocked
- [ ] Verify the adjacency list correctly parses `#N` dependency references from issue bodies
- [ ] Verify cycle-breaking targets the lowest-priority issue
- [ ] Verify explanatory comment is posted with cycle description

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)