### PR TITLE
feat: use gh issue develop for GitHub-linked branches

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -97,6 +97,12 @@ Return to `/forge` so other ready issues can proceed.
 ```bash
 git checkout main
 git pull origin main
+gh issue develop $ISSUE --name agent/issue-{N}-{slug} --checkout
+```
+
+This creates a branch linked to the issue in GitHub's "Development" sidebar. If `gh issue develop` fails (e.g., insufficient permissions or network error), fall back to local branch creation:
+
+```bash
 git checkout -b agent/issue-{N}-{slug}
 ```
 


### PR DESCRIPTION
Closes #30

## Summary

- Replace `git checkout -b` with `gh issue develop $ISSUE --name ... --checkout` in build skill Step 4
- Adds fallback to `git checkout -b` if `gh issue develop` fails
- Branch naming convention unchanged

## Test plan

- [ ] Verify Step 4 in `skills/build/SKILL.md` uses `gh issue develop` as primary
- [ ] Verify fallback to `git checkout -b` exists
- [ ] Slug generation instructions preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)