### PR TITLE
feat: add descriptive issue reference line to PR body template

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -201,6 +201,8 @@ gh pr create \
   --body "$(cat <<'EOF'
 Closes #{N}
 
+> This PR implements Issue #{N} and will close it automatically when merged.
+
 ## Changes
 
 [2-5 bullet points summarizing what was implemented]


### PR DESCRIPTION
Closes #31

## Summary

- Adds a blockquote line after `Closes #{N}` in the build skill's PR body template:
  `> This PR implements Issue #{N} and will close it automatically when merged.`
- Makes the auto-close behavior explicit for reviewers scanning the PR

## Test plan

- [ ] Verify PR body template in `skills/build/SKILL.md` Step 8 has the new line
- [ ] Line appears as a blockquote between `Closes #{N}` and `## Changes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)