### PR TITLE
feat: file triage issues for out-of-scope discoveries

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -130,6 +130,7 @@ This is where you write code. Follow these principles:
 4. **Use the Task tool for complex research.** If you need to understand an API or library, spawn a research sub-agent rather than guessing.
 5. **Work incrementally.** Make small, logical changes. Don't try to implement everything in one giant edit.
 6. **Test as you go.** Run the dev server (`pnpm dev`) to verify changes work when practical.
+7. **File triage issues for out-of-scope discoveries.** If you find bugs, missing error handling, or improvement opportunities outside the current issue's scope, file a `triage`-labeled issue for each one rather than fixing it inline. Stay focused on the current issue.
 
 ### Step 6b: Review and test (sub-agents)
 
@@ -288,7 +289,7 @@ After completing (success or failure), end with:
 - **Commit message format:** `feat: {title} (closes #{N})` for features, `fix:` for bugfixes, `chore:` for config.
 - **PR body must reference the issue** with `Closes #{N}`.
 - **Write `.forge-current-issue`** so the Stop hook knows which issue to comment on.
-- **Don't modify files outside the issue's scope.** Stay focused on what the issue asks for.
+- **Don't modify files outside the issue's scope.** Stay focused on what the issue asks for. If you discover something worth fixing, file a `triage` issue (see principle 7 in Step 6).
 - **Don't skip quality checks.** Even if you're confident, always run lint + typecheck + test + build.
 - **Don't skip sub-agents.** Always spawn review and test agents after implementation, even for small changes. The review agent catches issues the linter can't, and the test agent ensures coverage.
 - **Respect the build timeout.** Check elapsed time before Steps 6, 6b, 6c, 7, and 8. If the 30-minute limit is reached, commit WIP and escalate rather than continuing.

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -348,7 +348,7 @@ After completing (success or failure), end with:
 - **One issue per invocation.** Never batch multiple revision issues.
 - **No review or test sub-agents.** The human IS the reviewer. Tests already exist from the original `/build`. Only spawn the debug agent if quality checks fail.
 - **Preserve existing tests.** Do not modify test files unless a review comment specifically asks for it. If your code changes cause test failures, fix the implementation to match the tests, not the other way around.
-- **Don't exceed the issue's scope.** Only address what the reviewer asked for. Don't refactor surrounding code or add features.
+- **Don't exceed the issue's scope.** Only address what the reviewer asked for. Don't refactor surrounding code or add features. If you discover bugs or improvements outside scope, file a `triage`-labeled issue instead of fixing inline.
 - **Every comment must be resolved or escalated.** Don't silently skip feedback.
 - **Always push before updating labels.** The branch must be updated on the remote before marking the issue done.
 - **Write `.forge-current-issue`** so the Stop hook knows which issue to comment on.


### PR DESCRIPTION
Closes #33

## Summary

- Add principle 7 to build skill Step 6: file `triage`-labeled issues for bugs/improvements discovered outside current issue scope
- Update scope rule in build skill to cross-reference principle 7
- Add matching triage-filing rule to revise skill

## Test plan

- [ ] Verify build SKILL.md Step 6 has principle 7 about triage issues
- [ ] Verify build SKILL.md scope rule cross-references principle 7
- [ ] Verify revise SKILL.md rules section mentions triage filing

🤖 Generated with [Claude Code](https://claude.com/claude-code)