### PR TITLE
feat: enforce atomic commits in build and revise skills

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -193,9 +193,9 @@ git commit -m "feat: add hero section component"
 git add <files for change 2>
 git commit -m "chore: install framer-motion"
 
-# Only the FINAL commit gets (closes #{N})
+# Only the FINAL commit gets (closes #{N}). Use the appropriate type: feat/fix/chore.
 git add <remaining files>
-git commit -m "feat: {issue title} (closes #{N})"
+git commit -m "{type}: {issue title} (closes #{N})"
 
 # Push the branch
 git push -u origin agent/issue-{N}-{slug}

--- a/skills/revise/SKILL.md
+++ b/skills/revise/SKILL.md
@@ -355,4 +355,4 @@ After completing (success or failure), end with:
 - **Every comment must be resolved or escalated.** Don't silently skip feedback.
 - **Always push before updating labels.** The branch must be updated on the remote before marking the issue done.
 - **Write `.forge-current-issue`** so the Stop hook knows which issue to comment on.
-- **Commit message format:** `fix: address review feedback (#N)` — always use `fix:` prefix for revisions.
+- **Commit message format:** `fix: {descriptive message} (#N)` — always use `fix:` prefix for revisions. Use a specific description per commit when splitting atomic commits (e.g., `fix: rename handler to match convention (#N)`).


### PR DESCRIPTION
Closes #34

## Summary

- Add split-commit instructions to build skill Step 8 with examples showing one commit per logical change
- Only the final commit includes `(closes #{N})`
- Update build commit format rule to reflect multi-commit workflow
- Add matching atomic commit instructions to revise skill Step 8

## Test plan

- [ ] Verify build SKILL.md Step 8 has split-commit instructions and examples
- [ ] Verify only final commit gets `(closes #{N})`
- [ ] Verify build commit format rule updated
- [ ] Verify revise SKILL.md Step 8 has split-commit note and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)