### PR TITLE
feat: add post-merge branch cleanup to /forge orchestrator

### DIFF
--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -104,8 +104,8 @@ After syncing, clean up local branches for issues that have been closed (merged 
 
 ```bash
 # Delete local agent branches whose remote counterpart is gone (merged and auto-deleted)
-git remote prune origin
-git branch --list 'agent/*' | while read branch; do
+git remote prune origin 2>/dev/null || true
+git branch --format='%(refname:short)' --list 'agent/*' | while read -r branch; do
   if ! git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
     git branch -d "$branch" 2>/dev/null || true
   fi


### PR DESCRIPTION
Closes #35

## Summary

- Add Step 3.7 to `/forge` orchestrator between sync and routing
- Prunes stale remote-tracking refs (`git remote prune origin`)
- Deletes local `agent/*` branches whose remote counterpart is gone (merged and auto-deleted by GitHub)
- Non-blocking: failures are silently ignored

## Test plan

- [ ] Verify Step 3.7 exists in `skills/forge/SKILL.md` between 3.5 and 4
- [ ] Verify cleanup only deletes branches with no remote counterpart
- [ ] Verify failures don't block the orchestrator loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)