### PR TITLE
feat: poll for PR review changes and merges in forge run loop

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -594,20 +594,22 @@ if total > 0:
                         echo "[forge] Action required. Review open PRs and check GitHub issues."
                         echo "[forge] Polling for PR review changes every 60s (Ctrl+C to stop)..."
                         while true; do
-                            sleep 60
-                            # Check if any open agent PR has CHANGES_REQUESTED
-                            review_change=$(gh pr list --state open --json headRefName,reviewDecision \
-                                --jq '[.[] | select(.headRefName | startswith("agent/")) | select(.reviewDecision == "CHANGES_REQUESTED")] | length' 2>/dev/null || echo "0")
-                            # Check if any open agent PR was merged (no longer open)
-                            agent_prs=$(gh pr list --state open --json headRefName \
-                                --jq '[.[] | select(.headRefName | startswith("agent/"))] | length' 2>/dev/null || echo "1")
+                            # Fetch all open agent PRs in a single call
+                            if ! agent_pr_json=$(gh pr list --state open -L 200 --json headRefName,reviewDecision \
+                                --jq '[.[] | select(.headRefName | startswith("agent/"))]'); then
+                                echo "[forge] Failed to query GitHub PRs. Run 'gh auth refresh' or check connectivity."
+                                exit 1
+                            fi
+                            review_change=$(echo "$agent_pr_json" | jq '[.[] | select(.reviewDecision == "CHANGES_REQUESTED")] | length')
+                            agent_prs=$(echo "$agent_pr_json" | jq 'length')
                             if [ "$review_change" -gt 0 ]; then
                                 echo "[forge] Review comments detected. Restarting to handle revisions..."
                                 break
                             elif [ "$agent_prs" -eq 0 ]; then
-                                echo "[forge] PR merged. Restarting to continue build loop..."
+                                echo "[forge] No open agent PRs detected. Restarting to continue build loop..."
                                 break
                             fi
+                            sleep 60
                         done
                         ;;
                     error)


### PR DESCRIPTION
Closes #36

## Summary

- Replace immediate `exit 1` on `needs-human` in `forge run` with a polling loop
- Every 60s, checks for `CHANGES_REQUESTED` reviews on open `agent/*` PRs
- Also detects when all agent PRs have been merged (no longer open)
- On either detection, breaks out of polling and restarts the session
- `/sync` step 3d already handles relabeling `agent:done` → `agent:revision-needed` when `CHANGES_REQUESTED` is found

## Test plan

- [ ] Verify `forge run` polls instead of exiting on `needs-human`
- [ ] Verify `CHANGES_REQUESTED` detection triggers restart
- [ ] Verify PR merge detection (no open agent PRs) triggers restart
- [ ] Verify Ctrl+C still works during polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)