### PR TITLE
Add structured audit methodology to /plan

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -199,7 +199,7 @@ Do not commit these changes — /forge handles the branch, commit, and PR.
 
 ## Audit Mode
 
-When `graveyard/` exists, all original issues have been closed and `/forge` has re-invoked `/plan` to check for gaps. Your job is to compare what was requested against what was built and file issues for anything missing.
+When `/forge` Case E re-invokes `/plan` after all issues have been closed, `graveyard/` will exist (created during the initial planning run). Your job is to compare what was requested against what was built and file issues for anything missing.
 
 ### Audit Step 1: Gather context
 


### PR DESCRIPTION
## Summary
- Adds **Mode Detection** section to `/plan` — checks `graveyard/` existence to route between initial planning and audit
- Adds **Audit Mode** with 5 structured steps: gather context, spawn sub-agents with audit framing, synthesize gaps, file issues, summarize
- Reuses existing 4 sub-agents by prepending audit context rather than creating separate reference files
- Updates frontmatter description to mention audit mode

## Test plan
- [ ] Verify mode detection correctly distinguishes first run (no graveyard/) from audit run
- [ ] Verify audit sub-agents receive original requirements + closed issue summaries
- [ ] Verify gap issues use the same structured template as initial planning
- [ ] Verify "no gaps found" path produces summary without filing issues
- [ ] Verify audit issues get `agent:ready` (no blocked dependencies)

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)