### PR TITLE
Fix graveyard filename collision on same-day re-planning

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -173,7 +173,7 @@ post-planning instructions. Use Bash commands (not Write/Edit tools):
 
 ```bash
 mkdir -p graveyard
-cp PROMPT.md "graveyard/$(date +%Y-%m-%d).md"
+cp PROMPT.md "graveyard/$(date +%Y-%m-%d-%H%M%S).md"
 cat > PROMPT.md <<'PROMPT_EOF'
 Audit the current project against the original requirements archived in
 graveyard/. Review what was built (closed issues) and compare it to what


### PR DESCRIPTION
## Summary
- Changed `graveyard/$(date +%Y-%m-%d).md` to `graveyard/$(date +%Y-%m-%d-%H%M%S).md`
- Prevents overwriting the archive if `/plan` runs twice on the same day

## Test plan
- [ ] Verify the date format produces unique filenames (e.g., `2026-03-06-151300.md`)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)