### PR TITLE
Close completed milestones after all issues resolved

### DIFF
--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -223,7 +223,14 @@ gh issue list --state open --label "ai-generated" --limit 1000 --json number --j
 ```
 
 - **If new issues exist:** Continue the loop — re-invoke `/forge` to process them.
-- **If no new issues:** The project is complete. Announce completion and write the exit status.
+- **If no new issues:** The project is complete. Close any milestones that have no remaining open issues, then announce completion.
+
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   gh api "repos/$REPO/milestones" --jq '.[] | select(.open_issues == 0) | .number' | while read num; do
+     gh api "repos/$REPO/milestones/$num" -X PATCH -f state="closed"
+   done
+   ```
 
    ```
    Action: Announce completion


### PR DESCRIPTION
## Summary
- Added milestone cleanup step to `/forge` Case E (completion path)
- After audit finds no gaps, closes all milestones with zero open issues via `gh api`

## Test plan
- [ ] Read `skills/forge/SKILL.md` Case E — milestone closure happens before completion announcement
- [ ] Verify the `gh api` call correctly filters milestones with `open_issues == 0`

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)