### PR TITLE
fix: add --yes flag to vendor skills install commands

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -508,23 +508,26 @@ step_15b_vendor_skills() {
     local failed=0
 
     # Core Next.js / React knowledge
-    pnpm dlx skills add https://github.com/vercel-labs/next-skills --skill next-best-practices --yes 2>/dev/null || failed=1
-    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices --yes 2>/dev/null || failed=1
-    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines --yes 2>/dev/null || failed=1
+    local skills_flags="--yes --agent claude-code --copy"
+
+    # Core Next.js / React knowledge
+    pnpm dlx skills add https://github.com/vercel-labs/next-skills --skill next-best-practices $skills_flags 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices $skills_flags 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines $skills_flags 2>/dev/null || failed=1
 
     # Vercel platform
-    pnpm dlx skills add https://github.com/vercel/vercel --skill vercel-cli --yes 2>/dev/null || failed=1
-    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-deploy --yes 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel/vercel --skill vercel-cli $skills_flags 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-deploy $skills_flags 2>/dev/null || failed=1
 
     # Browser automation & visual testing
-    pnpm dlx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser --yes 2>/dev/null || failed=1
-    pnpm dlx skills add https://github.com/vercel-labs/before-and-after --skill before-and-after --yes 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser $skills_flags 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/before-and-after --skill before-and-after $skills_flags 2>/dev/null || failed=1
 
     # Testing
-    pnpm dlx skills add https://github.com/microsoft/playwright-cli --skill playwright-cli --yes 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/microsoft/playwright-cli --skill playwright-cli $skills_flags 2>/dev/null || failed=1
 
     # Self-discovery meta-skill
-    pnpm dlx skills add https://github.com/vercel-labs/skills --skill find-skills --yes 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/skills --skill find-skills $skills_flags 2>/dev/null || failed=1
 
     if [ "$failed" -eq 0 ]; then
         touch .claude/skills/.vendor-skills-installed


### PR DESCRIPTION
## Summary

- Adds `--yes --agent claude-code --copy` to all 9 `pnpm dlx skills add` calls in `step_15b_vendor_skills()`
- `--yes` skips the interactive agent selection prompt that blocks in non-interactive contexts (piped stdin during `forge init`)
- `--agent claude-code` targets only Claude Code, avoiding the unnecessary `.agents/` intermediary directory
- `--copy` copies files directly into `.claude/skills/` instead of symlinking

## Test plan

- [ ] Run `forge init` on a fresh project and verify vendor skills appear in `.claude/skills/` as real files (not symlinks)
- [ ] Verify no `.agents/` directory is created

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)