### PR TITLE
fix: suppress raw JSON output from step 19b repo settings

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -708,7 +708,7 @@ step_19b_repo_settings() {
     if ! gh api "repos/$repo" \
         -X PATCH \
         -H "Accept: application/vnd.github+json" \
-        --input - <<'SETTINGS' 2>/dev/null; then
+        --input - <<'SETTINGS' >/dev/null 2>/dev/null; then
 {
   "delete_branch_on_merge": true,
   "allow_update_branch": true,


### PR DESCRIPTION
## Summary

- Adds `>/dev/null` to the `gh api` PATCH call in `step_19b_repo_settings()`
- The call already suppressed stderr (`2>/dev/null`) but not stdout, causing ~100 lines of raw repository JSON to dump during bootstrap

## Test plan

- [ ] Run `forge init` and verify step 19b produces only the `ok` message, no JSON output

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)