### PR TITLE
fix: branch protection no longer falsely skips on GitHub Free 403

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -650,7 +650,9 @@ step_19_branch_protection() {
     fi
     # Check if a forge ruleset already exists
     local existing
-    existing=$(gh api "repos/$repo/rulesets" -q '[.[] | select(.name == "forge-main-protection")] | length' 2>/dev/null || echo "0")
+    if ! existing=$(gh api "repos/$repo/rulesets" -q '[.[] | select(.name == "forge-main-protection")] | length' 2>/dev/null); then
+        existing="0"
+    fi
     if [ "$existing" != "0" ]; then
         skip "$label"
         return


### PR DESCRIPTION
## Summary

- Checks the exit code of `gh api repos/$repo/rulesets` before trusting its output
- On GitHub Free (private repos), the rulesets API returns 403 on stdout as JSON. The old `|| echo "0"` appended "0" to the JSON string, producing `'{"message":"Upgrade..."}0'` which is `!= "0"`, falsely triggering the skip
- Now a failed API call sets `existing="0"`, so the step proceeds to attempt creating the ruleset — which also fails with 403 and triggers the existing actionable warning

Closes #69

## Test plan

- [ ] `forge init` on GitHub Free (private repo) — step 19 should attempt creation and warn, not falsely report "already done"
- [ ] `forge init` on GitHub Pro/Team — step 19 should still correctly skip if ruleset exists
- [ ] `forge init --resume` — idempotent behavior preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)