### PR TITLE
fix: rename vercel-deploy to deploy-to-vercel

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -543,7 +543,7 @@ step_15b_vendor_skills() {
 
     # Vercel platform
     pnpm dlx skills add https://github.com/vercel/vercel --skill vercel-cli $skills_flags 2>/dev/null || failed=1
-    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-deploy $skills_flags 2>/dev/null || failed=1
+    pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill deploy-to-vercel $skills_flags 2>/dev/null || failed=1
 
     # Browser automation & visual testing
     pnpm dlx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser $skills_flags 2>/dev/null || failed=1

--- a/install.sh
+++ b/install.sh
@@ -256,7 +256,7 @@ case "${1:-}" in
             pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-react-best-practices 2>/dev/null || true
             pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill web-design-guidelines 2>/dev/null || true
             pnpm dlx skills add https://github.com/vercel/vercel --skill vercel-cli 2>/dev/null || true
-            pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill vercel-deploy 2>/dev/null || true
+            pnpm dlx skills add https://github.com/vercel-labs/agent-skills --skill deploy-to-vercel 2>/dev/null || true
             pnpm dlx skills add https://github.com/vercel-labs/agent-browser --skill agent-browser 2>/dev/null || true
             pnpm dlx skills add https://github.com/vercel-labs/before-and-after --skill before-and-after 2>/dev/null || true
             pnpm dlx skills add https://github.com/microsoft/playwright-cli --skill playwright-cli 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Renames `vercel-deploy` to `deploy-to-vercel` in both `bootstrap/setup.sh` and `install.sh`
- The skill was renamed upstream in `vercel-labs/agent-skills`

Closes #70

## Test plan

- [ ] `forge init` — vendor skills step should install `deploy-to-vercel` without "No matching skills found" error
- [ ] `forge upgrade` — same fix applied to the upgrade path in `install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)