### PR TITLE
fix: resolve false warnings in forge doctor

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,12 +448,12 @@ case "${1:-}" in
             echo -e "  ${RED}✗${NC} GitHub not authenticated — run: gh auth login"
         fi
 
-        local vercel_cmd="vercel"
-        command -v vercel &>/dev/null || vercel_cmd="${PNPM_HOME:-$HOME/Library/pnpm}/vercel"
-        if "$vercel_cmd" whoami &>/dev/null 2>&1; then
-            echo -e "  ${GREEN}✓${NC} Vercel authenticated"
-        else
-            echo -e "  ${YELLOW}⚠${NC} Vercel not authenticated — run: vercel login"
+        if command -v vercel &>/dev/null || [ -x "${PNPM_HOME:-$HOME/Library/pnpm}/vercel" ]; then
+            if (vercel whoami &>/dev/null 2>&1 || "${PNPM_HOME:-$HOME/Library/pnpm}/vercel" whoami &>/dev/null 2>&1); then
+                echo -e "  ${GREEN}✓${NC} Vercel authenticated"
+            else
+                echo -e "  ${YELLOW}⚠${NC} Vercel not authenticated — run: vercel login"
+            fi
         fi
 
         # 6. Check disk space


### PR DESCRIPTION
## Summary

Three false warning fixes in `forge doctor`:

1. **Vercel CLI "not installed"** — `command -v vercel` fails when PNPM_HOME isn't in PATH. Added fallback check at `${PNPM_HOME:-$HOME/Library/pnpm}/vercel`
2. **Vercel "not authenticated"** — same root cause; `vercel whoami` can't run if the binary isn't found. Uses the same PNPM_HOME fallback
3. **Skills "outdated"** — `diff -rq` compared entire directories, so `.DS_Store` and `.vendor-skills-installed` triggered false positives. Added `--exclude='.*' --exclude='*.installed'`

Closes #74

## Test plan

- [ ] `forge doctor` with Vercel installed via pnpm (PNPM_HOME not in PATH) — should detect Vercel CLI and auth status
- [ ] `forge doctor` with `.DS_Store` or `.vendor-skills-installed` in `.claude/skills/` — should report skills as up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)