### PR TITLE
fix: test deps never installed due to pnpm list exit code bug

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -323,7 +323,7 @@ step_10b_scaffold() {
 # Step 10c: Install test dependencies
 step_10c_test_deps() {
     local label="10c. Test dependencies installed"
-    if pnpm list vitest &>/dev/null 2>&1; then
+    if node -e "const p=require('./package.json'); process.exit(p.devDependencies?.vitest ? 0 : 1)" 2>/dev/null; then
         skip "$label"
         return
     fi


### PR DESCRIPTION
## Summary

- Replaces `pnpm list vitest` idempotency check with a direct `package.json` lookup
- `pnpm list` in pnpm 10.x returns exit code 0 even for missing packages, so the check always passed and test dependencies were never installed
- Every bootstrapped project had test config files (`vitest.config.ts`, `playwright.config.ts`) but no actual test packages — `pnpm test` always failed

Closes #75

## Test plan

- [ ] `forge init` on a fresh project — vitest, @testing-library/*, @playwright/test should appear in `package.json` devDependencies
- [ ] `pnpm test` should work (not "vitest: command not found")
- [ ] `forge init --resume` after deps already installed — step should skip correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)