### PR TITLE
fix: forge update now regenerates the CLI (#90)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,10 @@ FORGE_REPO="$FORGE_HOME/repo"
 FORGE_BIN="$FORGE_HOME/bin"
 FORGE_REMOTE="https://github.com/allan-mobley-jr/forge.git"
 
+# CLI-only mode: skip banner/clone/PATH, just regenerate the CLI binary.
+# Used by `forge update` to refresh the CLI after pulling the repo.
+if [ "${FORGE_CLI_ONLY:-}" != "1" ]; then
+
 # --- Retry helper ---
 
 retry() {
@@ -89,6 +93,8 @@ else
     retry git clone --quiet "$FORGE_REMOTE" "$FORGE_REPO"
     echo -e "${GREEN}Forge installed to $FORGE_REPO${NC}"
 fi
+
+fi  # end FORGE_CLI_ONLY != 1
 
 # --- Step 3: Create the forge command ---
 
@@ -205,6 +211,8 @@ case "${1:-}" in
     update)
         echo "Updating Forge..."
         git -C "$FORGE_REPO" pull
+        # Regenerate CLI from updated repo
+        FORGE_CLI_ONLY=1 bash "$FORGE_REPO/install.sh"
         echo "Forge updated to latest version."
         echo ""
         echo "  Run 'forge doctor' inside a project to check health."
@@ -719,8 +727,8 @@ if total > 0:
                 echo ""
                 echo "Usage: forge update"
                 echo ""
-                echo "Pulls the latest version of Forge from GitHub."
-                echo "Run 'forge upgrade' inside a project to update its artifacts."
+                echo "Pulls the latest version of Forge from GitHub and regenerates"
+                echo "the CLI. Run 'forge upgrade' inside a project to update its artifacts."
                 ;;
             upgrade)
                 echo "forge upgrade — Update project artifacts"
@@ -843,6 +851,8 @@ FORGE_CMD
 
 chmod +x "$FORGE_BIN/forge"
 
+if [ "${FORGE_CLI_ONLY:-}" != "1" ]; then
+
 # --- Step 4: Add to PATH ---
 
 SHELL_RC=""
@@ -888,3 +898,5 @@ if [ -n "$SHELL_RC" ]; then
     echo -e "  ${YELLOW}Note:${NC} Restart your terminal or run ${BOLD}source $SHELL_RC${NC} to use the forge command."
     echo ""
 fi
+
+fi  # end FORGE_CLI_ONLY != 1


### PR DESCRIPTION
## Summary

- `forge update` now regenerates `~/.forge/bin/forge` after pulling the repo
- Uses `FORGE_CLI_ONLY=1` env var to re-run install.sh in a mode that only writes the CLI heredoc + chmod — skips banner, git clone, and PATH setup
- Updates help text to reflect the new behavior

Closes #90

## Test plan

- [ ] `bash -n install.sh` passes
- [ ] Fresh install (`curl | bash`) still works end-to-end
- [ ] `forge update` pulls repo AND regenerates CLI
- [ ] After `forge update`, `forge version` reflects the latest code

🤖 Generated with [Claude Code](https://claude.com/claude-code)