### PR TITLE
fix: replace invalid job-level hashFiles() with step-level check

### DIFF
--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
       - name: Check for E2E tests
         id: check
         run: |
-          if find e2e -name '*.spec.*' -o -name '*.test.*' 2>/dev/null | grep -q .; then
+          if [ -d e2e ] && find e2e -type f \( -name '*.spec.*' -o -name '*.test.*' \) 2>/dev/null | grep -q .; then
             echo "has_tests=true" >> "$GITHUB_OUTPUT"
           else
             echo "No E2E test files found — skipping"
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
           fi
       - uses: pnpm/action-setup@v4
         if: steps.check.outputs.has_tests == 'true'


### PR DESCRIPTION
## Summary

- `hashFiles()` is not available in job-level `if` conditions in GitHub Actions, causing the CI workflow to fail validation on every push with `Unrecognized function: 'hashFiles'`
- Replaced with a step-level check: after `actions/checkout`, a `find` command detects `*.spec.*` / `*.test.*` files in `e2e/` and sets a step output
- All remaining e2e steps are gated on that output, preserving the original intent (skip Playwright setup when no e2e tests exist)

Closes #92

## Test plan

- [ ] Verify workflow YAML passes GitHub Actions validation (no more "Invalid workflow file" error)
- [ ] With no e2e test files: e2e job runs checkout + check step only, skips Playwright install/build/test
- [ ] With e2e test files present: all steps execute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)