### PR TITLE
Add /fix-issue skill for issue-to-PR workflow

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,7 +1,7 @@
 ---
 name: fix-issue
 description: Work through a GitHub issue end-to-end — branch, plan, implement, review, PR, wait for merge. Use when tackling issues from the backlog one at a time.
-allowed-tools: Bash(gh *), Bash(git *), Read, Glob, Grep, Edit, Write, Agent
+allowed-tools: Bash(gh *), Bash(git *), Read, Glob, Grep, Edit, Write
 ---
 
 # /fix-issue — Issue-to-PR Workflow
@@ -22,18 +22,18 @@ Work through one GitHub issue from start to finish. One issue at a time, sequent
 If no issue number is given, find the lowest-numbered open issue:
 
 ```bash
-gh issue list --state open --limit 1 --json number,title,body --jq '.[0]'
+gh issue list --state open --limit 100 --json number,title,body --jq 'sort_by(.number) | .[0]'
 ```
 
 Read the issue thoroughly. Understand what needs to change and why.
 
 ### Step 2: Create a branch
 
-Branch name format: `fix/<issue-number>-<short-slug>`
+Branch name format: `fix/<issue-number>-<short-slug>` for bugs, `feat/<number>-<slug>` for features.
 
 ```bash
 git checkout main && git pull
-git checkout -b fix/<number>-<slug>
+git checkout -b fix/<number>-<slug>   # or feat/<number>-<slug>
 ```
 
 The slug should be 2-4 words from the issue title, kebab-case. Example: `fix/94-doctor-skills-outdated`
@@ -97,10 +97,11 @@ After creating the PR, stop and tell the user:
 
 ```
 PR created: <url>
-Waiting for review. Run /fix-issue to pick up the next issue, or /resolve-pr-comments if review feedback comes in.
+Waiting for review. Run /resolve-pr-comments when review feedback comes in.
+After the PR merges, run /fix-issue to pick up the next issue.
 ```
 
-Do NOT start the next issue automatically. Wait for the user to direct you.
+Do NOT start the next issue automatically. Wait for the current PR to merge first.
 
 ## Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,7 @@ research/        — ad-hoc research notes and scratchpad (not committed)
 
 When working through GitHub issues, use `/fix-issue <number>` (or `/fix-issue` for the next open issue). This enforces the full cycle: branch, plan, implement, self-review, PR, wait for merge. One issue at a time — never start the next until the current PR is merged.
 
-After a PR merges, clean up before moving on:
-```
-git checkout main && git pull && git branch -d <branch> && git remote prune origin
-```
+After a PR merges, clean up before moving on (see [After a PR is merged](#after-a-pr-is-merged) below).
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/fix-issue.md` — a reusable skill that enforces the full issue-to-PR cycle: pick issue, branch, plan, implement, self-review, PR, wait for merge
- Updates `CLAUDE.md` with an Issue Workflow section directing use of `/fix-issue` when working through the backlog

## Test plan
- [ ] Run `/fix-issue 94` and verify it follows the prescribed workflow
- [ ] Confirm `/fix-issue` (no args) picks the lowest open issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)