### PR TITLE
Fix forge update to run full idempotent installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -205,12 +205,12 @@ case "${1:-}" in
         fi
         ;;
     update)
-        # Re-run the full installer, which is idempotent:
-        # - pulls the repo (or skips if up-to-date)
+        # Pull first so install.sh is up-to-date before bash parses it.
+        # Then re-run the full installer, which is idempotent:
+        # - pulls the repo again (no-op, already up-to-date)
         # - regenerates this CLI from the updated heredoc
         # - skips PATH setup if already configured
-        # This avoids the chicken-and-egg problem where an old CLI
-        # can't regenerate itself because it predates the mechanism.
+        git -C "$FORGE_REPO" pull
         bash "$FORGE_REPO/install.sh"
         ;;
     upgrade)


### PR DESCRIPTION
## Summary
- `forge update` now runs the full `install.sh` instead of a `FORGE_CLI_ONLY` partial mode
- Removes the `FORGE_CLI_ONLY` mechanism entirely — the installer is already idempotent
- Fixes the chicken-and-egg problem where old CLIs couldn't regenerate themselves

Closes #95

## Test plan
- [ ] Run `forge update` — should show the banner, pull repo, regenerate CLI, set up PATH (all idempotent)
- [ ] Run `forge doctor` in a project — Vercel CLI should be detected via the PNPM_HOME fallback
- [ ] Run `forge update` again — should report "Already up to date" and complete cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)