### PR TITLE
Fix AGENTS.md codemod with @canary fallback

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -419,15 +419,16 @@ PLAYWRIGHT
 }
 
 # Step 10e: Generate AGENTS.md (Next.js docs index)
-# The agents-md subcommand is canary-only as of March 2026.
-# This step silently no-ops until it ships in a stable release.
+# Try @latest first; fall back to @canary where the subcommand already exists.
 step_10e_agents_md() {
     local label="10e. AGENTS.md (Next.js docs index)"
     if [ -f AGENTS.md ]; then
         skip "$label"
         return
     fi
-    pnpm dlx @next/codemod@latest agents-md --output AGENTS.md >/dev/null 2>&1 || true
+    pnpm dlx @next/codemod@latest agents-md --output AGENTS.md >/dev/null 2>&1 \
+      || pnpm dlx @next/codemod@canary agents-md --output AGENTS.md >/dev/null 2>&1 \
+      || true
     if [ -f AGENTS.md ]; then
         ok "$label"
     fi

--- a/install.sh
+++ b/install.sh
@@ -270,9 +270,11 @@ case "${1:-}" in
             printf '\n# Vendor skills sentinel\n.claude/skills/.vendor-skills-installed\n' >> .gitignore
         fi
 
-        # 4c. Generate AGENTS.md if missing (silently no-ops until codemod ships stable)
+        # 4c. Generate AGENTS.md if missing (try @latest, fall back to @canary)
         if [ ! -f AGENTS.md ]; then
-            pnpm dlx @next/codemod@latest agents-md --output AGENTS.md >/dev/null 2>&1 || true
+            pnpm dlx @next/codemod@latest agents-md --output AGENTS.md >/dev/null 2>&1 \
+              || pnpm dlx @next/codemod@canary agents-md --output AGENTS.md >/dev/null 2>&1 \
+              || true
             [ -f AGENTS.md ] && echo -e "  ${GREEN}✓${NC} AGENTS.md generated"
         fi
 


### PR DESCRIPTION
## Summary
- Fixes the AGENTS.md codemod invocation in both bootstrap (`setup.sh` step 10e) and upgrade path (`install.sh` step 4c)
- The `agents-md` subcommand only exists in `@next/codemod@canary`, not `@latest`
- Try `@latest` first (auto-works when stable ships), fall back to `@canary` (works today)

Closes #96

## Test plan
- [ ] Run `forge init` in a Next.js project — AGENTS.md is generated via the `@canary` fallback
- [ ] Run `forge upgrade` — AGENTS.md is generated if missing
- [ ] Confirm `.next-docs/` directory is created (sparse-checkout of Next.js docs)
- [ ] Confirm AGENTS.md contains `BEGIN:nextjs-agent-rules` / `END:nextjs-agent-rules` markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)