### PR TITLE
fix: prevent EOF parse error after forge update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -212,6 +212,7 @@ case "${1:-}" in
         # - skips PATH setup if already configured
         git -C "$FORGE_REPO" pull
         bash "$FORGE_REPO/install.sh"
+        exit $?
         ;;
     upgrade)
         # Colors for upgrade output


### PR DESCRIPTION
## Summary
- `forge update` calls `bash install.sh` which overwrites the currently-running CLI script via heredoc. When that returns, the shell tries to continue reading the modified file and hits an EOF parse error (exit code 2).
- Added `exit $?` after the `bash` call so the script exits immediately with the correct exit code, before the shell re-reads the changed file.

Closes #108

## Test plan
- Run `forge update` — should complete cleanly with exit code 0 (no EOF parse error)
- Verify the update actually applies (check `forge --version` or inspect `~/.forge/bin/forge`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)