### PR TITLE
fix: step 8 vercel skip on --resume

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -256,8 +256,13 @@ step_08_vercel() {
         pnpm_home=$(grep -m1 'export PNPM_HOME=' "$HOME/.zshrc" 2>/dev/null | sed 's/export PNPM_HOME="//' | sed 's/"$//')
         if [ -n "${pnpm_home:-}" ]; then
             export PNPM_HOME="$pnpm_home"
-            export PATH="$PNPM_HOME:$PATH"
         fi
+    fi
+    if [ -n "${PNPM_HOME:-}" ]; then
+        case ":$PATH:" in
+            *":$PNPM_HOME:"*) ;;
+            *) export PATH="$PNPM_HOME:$PATH" ;;
+        esac
     fi
     if command -v vercel &>/dev/null; then
         skip "$label"


### PR DESCRIPTION
## Summary
- On `--resume`, `PNPM_HOME` is in `.zshrc` but not in the current shell's PATH, so `command -v vercel` fails and step 8 re-installs vercel unnecessarily.
- Moved the `PNPM_HOME` sourcing logic before the skip check so vercel is findable on PATH during resume.

Closes #109

## Test plan
- Run `forge init` to completion, then run `forge init --resume` — step 8 should show "already done" instead of re-installing vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)