### PR TITLE
fix: harden forge update and forge doctor robustness

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ fi
 
 if [ -d "$FORGE_REPO/.git" ]; then
     echo -e "${BLUE}Updating Forge...${NC}"
-    git -C "$FORGE_REPO" fetch --quiet
+    retry git -C "$FORGE_REPO" fetch --quiet
     git -C "$FORGE_REPO" reset --hard origin/main --quiet
     echo -e "${GREEN}Forge updated.${NC}"
 else
@@ -419,8 +419,13 @@ if plugins:
             artifacts_outdated=true
         fi
 
-        if jq -S '{permissions, hooks}' .claude/settings.json 2>/dev/null | \
-           diff -q - <(jq -S '{permissions, hooks}' "$FORGE_REPO/hooks/settings.json") &>/dev/null; then
+        if command -v jq &>/dev/null; then
+            hooks_match=$(jq -S '{permissions, hooks}' .claude/settings.json 2>/dev/null | \
+                diff -q - <(jq -S '{permissions, hooks}' "$FORGE_REPO/hooks/settings.json" 2>/dev/null) &>/dev/null && echo y || echo n)
+        else
+            hooks_match=$(diff -q .claude/settings.json "$FORGE_REPO/hooks/settings.json" &>/dev/null && echo y || echo n)
+        fi
+        if [ "$hooks_match" = "y" ]; then
             echo -e "  ${GREEN}✓${NC} Hooks up-to-date"
         else
             echo -e "  ${YELLOW}⚠${NC} Hooks outdated"


### PR DESCRIPTION
## Summary

- **`forge update`**: Replace fragile two-step `git pull` + local `bash install.sh` with a single `curl` of the remote installer — eliminates dirty-repo failures, redundant double-pull, and `rc: unbound variable` error
- **Repo sync (install.sh)**: Use `fetch` + `reset --hard` instead of `pull` so local changes in `~/.forge/repo` can't block updates
- **`forge doctor`**: Compare only `permissions` and `hooks` keys via `jq` instead of byte-level `diff`, ignoring runtime keys like `enabledPlugins` that Claude Code appends at runtime

## Test plan

- [ ] Dirty `~/.forge/repo` (e.g. `echo test >> ~/.forge/repo/README.md`), run `forge update` — should succeed
- [ ] Run `forge doctor` from a Forge project where Claude Code has added `enabledPlugins` — hooks should report "up-to-date"

🤖 Generated with [Claude Code](https://claude.com/claude-code)