### PR TITLE
fix: add packages field to pnpm-workspace.yaml in bootstrap

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -351,7 +351,10 @@ step_10b2_fix_pnpm_workspace() {
     info "  Adding packages field to pnpm-workspace.yaml..."
     local tmp
     tmp=$(mktemp)
-    printf 'packages:\n  - '\''.'\''\n' > "$tmp"
+    cat > "$tmp" <<'EOF'
+packages:
+  - '.'
+EOF
     cat pnpm-workspace.yaml >> "$tmp"
     mv "$tmp" pnpm-workspace.yaml
     ok "$label"


### PR DESCRIPTION
## Summary
- Adds new idempotent bootstrap step `10b2` that prepends `packages: ['.']` to `pnpm-workspace.yaml` if the field is missing
- `create-next-app` generates `pnpm-workspace.yaml` with only `ignoredBuiltDependencies` but no `packages` field, causing CI to fail at `actions/setup-node@v4` when pnpm runs `pnpm store path --silent`
- Step runs between scaffold (10b) and test deps (10c), skips safely if file doesn't exist or already has the field

## Test plan
- [ ] Run `forge init` on a fresh project and verify `pnpm-workspace.yaml` contains `packages: ['.']` at the top
- [ ] Run `forge init --resume` on the same project and verify step skips (idempotent)
- [ ] Verify CI passes with the patched workspace file

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)