### PR TITLE
fix: add passWithNoTests to vitest config in bootstrap

### DIFF
--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -396,6 +396,7 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     globals: true,
+    passWithNoTests: true,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Adds `passWithNoTests: true` to the vitest config written by bootstrap step 10d
- Freshly bootstrapped projects have no test files, causing `vitest run` to exit with code 1 and block all PRs in CI
- Single-line fix at the source — no CI workflow changes needed

Closes #133

## Test plan
- [ ] Run `forge init` on a fresh project, push a PR, and verify CI passes without any test files
- [ ] Add a test file and verify vitest still runs tests normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)