### PR TITLE
fix: response detection fails when agent and human share same account

### DIFF
--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -134,12 +134,14 @@ RESPONSE=$(gh issue view "$ISSUE" --json comments --jq '
   | if . == null then null
     else
       .key as $qi
-      | [$c[range($qi + 1; $c | length)] | select(.body | test("^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict)") | not)] | last
+      | [$c[range($qi + 1; $c | length)] | select(.body | test("^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict|Acknowledged)") | not)] | last
       | .body
     end')
 
 # Post acknowledgment referencing the response
-gh issue comment "$ISSUE" --body "Acknowledged response. Resuming work on this issue.
+gh issue comment "$ISSUE" --body "## Acknowledged
+
+Resuming work on this issue.
 
 > ${RESPONSE}"
 

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -169,7 +169,7 @@ for ISSUE_NUM in $NEEDS_HUMAN; do
     | if . == null then false
       else
         .key as $qi
-        | [$c[range($qi + 1; $c | length)] | select(.body | test("^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict)") | not)]
+        | [$c[range($qi + 1; $c | length)] | select(.body | test("^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict|Acknowledged)") | not)]
         | length > 0
       end')
 


### PR DESCRIPTION
## Summary
- Replace author-based response detection (`author.login != $agent`) with content-based detection in both `/sync` and `/forge` skills
- Human responses are identified by the absence of known agent escalation headers (`## Agent Question`, `## Build Failed`, etc.) rather than by differing author
- Fixes the default setup where `gh` CLI is authenticated as the repo owner

Closes #138

## Test plan
- Authenticate `gh` as the repo owner (the default Forge setup)
- Let the agent post an `## Agent Question` comment on an issue
- Respond via GitHub web UI using the same account
- Run `/sync` — response should now be detected
- Run `/forge` — should route to Case A1 (responded) and extract the response text

🤖 Generated with [Claude Code](https://claude.com/claude-code)