### PR TITLE
fix: content-based human response detection in forge run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -753,7 +753,7 @@ print('waiting')
 import json, sys, re
 from datetime import datetime, timezone
 issues = json.load(sys.stdin)
-pattern = re.compile(r'^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict)', re.MULTILINE)
+pattern = re.compile(r'^## (Agent Question|Build Failed|Revision Limit Reached|Merge Conflict|Acknowledged)', re.MULTILINE)
 now = datetime.now(timezone.utc)
 for issue in issues:
     comments = issue.get('comments', [])


### PR DESCRIPTION
## Summary
- Replace author-based detection (`author != q_author`) with content-based detection in the `forge run` polling loop
- Any comment after the last agent escalation that doesn't start with a known agent header (`## Agent Question`, `## Build Failed`, etc.) is treated as a human response
- Aligns with `/sync`'s approach from PR #141, fixing single-account setups where the same GitHub account is both agent and human
- Added `Acknowledged` to the header pattern to match `/sync`

Closes #145

## Test plan
- On a single-account setup, post a human response on an `agent:needs-human` issue — `forge run` should detect it and restart
- Verify agent comments (with structured headers) don't trigger false positives
- Verify the 24h timeout path is unaffected (separate code block, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)