### PR TITLE
Always abort merge probe in reviser conflict check

### DIFF
--- a/agents/resolve-reviser.md
+++ b/agents/resolve-reviser.md
@@ -101,18 +101,18 @@ gh run view <run-id> --log-failed
 
 ### 5. Handle Merge Conflicts
 
-Check for conflicts:
+Probe for conflicts (always abort — this is a check, not an actual merge):
 
 ```bash
 git merge main --no-commit --no-ff 2>&1
+merge_result=$?
+git merge --abort 2>/dev/null || true
 ```
 
-**Simple conflicts** (< 3 files, clear resolution): resolve them.
-**Complex conflicts** (> 3 files or unclear resolution): abort merge, post BLOCKED status.
+If `merge_result` is non-zero, conflicts exist:
 
-```bash
-git merge --abort
-```
+**Simple conflicts** (< 3 files, clear resolution): rebase onto main and resolve them.
+**Complex conflicts** (> 3 files or unclear resolution): post BLOCKED status.
 
 ### 6. Apply Fixes
 


### PR DESCRIPTION
## Summary
- The reviser's merge conflict check (`git merge main --no-commit --no-ff`) only aborted on complex conflicts. On no-conflict, the merge stayed staged and its changes would silently roll into the next review feedback commit.
- Now the probe always runs `git merge --abort` regardless of outcome, making it a pure check with no side effects.
- Simple conflict resolution changed from in-place merge to rebase, avoiding the same staged-merge problem.

Closes #162

## Test plan
- [ ] Read the updated conflict check flow and verify `git merge --abort` always runs after the probe
- [ ] Verify no-conflict path no longer leaves staged changes
- [ ] Verify simple conflict path uses rebase instead of in-place merge resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)