### PR TITLE
Warn when using short-lived OAuth for forge run

### DIFF
--- a/cli/forge.sh
+++ b/cli/forge.sh
@@ -517,7 +517,7 @@ except:
             echo -e "  ${GREEN}✓${NC} Claude auth: long-lived token (setup-token)"
         else
             echo -e "  ${YELLOW}⚠${NC} Claude auth: short-lived OAuth — may expire during forge run"
-            echo "    Run 'claude setup-token' and set CLAUDE_CODE_OAUTH_TOKEN in ~/.zshrc"
+            echo "    Run 'claude setup-token' and set CLAUDE_CODE_OAUTH_TOKEN in your shell profile"
         fi
 
         # 6. Check labels
@@ -708,11 +708,12 @@ except:
                 exit 1
             fi
 
-            # Warn if using short-lived OAuth (no long-lived token configured)
-            if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            # Warn if using short-lived OAuth (no long-lived token configured) — once per run
+            if [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${_forge_oauth_warned:-}" ]; then
+                _forge_oauth_warned=1
                 echo -e "[forge] ${YELLOW}Warning:${NC} No long-lived auth token detected."
                 echo "  Short-lived OAuth tokens expire after ~8-12h and may fail during headless runs."
-                echo "  Run 'claude setup-token' and set CLAUDE_CODE_OAUTH_TOKEN in ~/.zshrc."
+                echo "  Run 'claude setup-token' and set CLAUDE_CODE_OAUTH_TOKEN in your shell profile."
                 echo "  See: https://docs.anthropic.com/en/docs/claude-code/cli-usage#non-interactive-mode"
                 echo ""
             fi


### PR DESCRIPTION
## Summary
- `forge doctor` now shows Claude auth method in the connectivity section: API key, long-lived token (setup-token), or short-lived OAuth with a warning
- `forge run` pre-flight warns if neither `ANTHROPIC_API_KEY` nor `CLAUDE_CODE_OAUTH_TOKEN` is set, recommending `claude setup-token`
- Filed #179 as a follow-up for prompting/automating setup-token during `forge init`

Closes #168

## Test plan
- [ ] Run `forge doctor` without `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` set — should show yellow warning
- [ ] Run `forge doctor` with `ANTHROPIC_API_KEY` set — should show green checkmark "API key"
- [ ] Run `forge doctor` with `CLAUDE_CODE_OAUTH_TOKEN` set — should show green checkmark "long-lived token"
- [ ] Verify `forge run` pre-flight shows the warning when no long-lived token is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)