### PR TITLE
docs: update README to reflect 4-pipeline architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Run `forge run` in the project directory to start the bash-orchestrated pipeline
   │        │                              forge-tempering-orchestrator│
   │        │                                                          │
   │        ├── PR needs changes ────────▶ Revision cycle              │
-  │        │                              tempering-reviser agent     │
+  │        │                              forge-tempering-orchestrator│
+  │        │                              <issue> --revise            │
   │        │                                                          │
   │        ├── All issues done ────────▶ Honing pipeline              │
   │        │                              6 stage agents via          │
@@ -223,6 +224,7 @@ Only one issue is ever active. The agent works on the lowest-numbered open issue
 | `tempering:reviewer` .. `tempering:reviser` | The tempering pipeline is running this stage. |
 | `honing` | Honing tracking issue (maintenance audit in progress). |
 | `honing:triager` .. `honing:filer` | The honing pipeline is running this stage. |
+| `smelting:pass-1`, `smelting:pass-2`, etc. | Pass tracking — which pass the pipeline is on for this issue. |
 | `agent:done` | The agent finished and opened a PR. Waiting for CI (and Copilot review, if enabled) before auto-merge. |
 | `agent:needs-human` | The agent got stuck and needs your input. Check the issue comments for the question. |
 | `ai-generated` | The agent created this issue or PR. Tells you at a glance what the agent filed vs. what you filed. |


### PR DESCRIPTION
## Summary
- Replace all "Creating pipeline" / "Resolving pipeline" references with Smelting, Hammering, Tempering, and Honing
- Update the label system table to match actual `FORGE_REQUIRED_LABELS` from `cli/forge-lib.sh`
- Update the repository structure to list all 4 orchestrators and 24 agents grouped by pipeline

Closes #186

## Test plan
- [ ] Verify `grep -iE 'creat.*pipeline|resolv.*pipeline|forge-create-|forge-resolve-|agent:create-|agent:resolve-' README.md` returns no matches
- [ ] Cross-reference label table with `FORGE_REQUIRED_LABELS` in `cli/forge-lib.sh`
- [ ] Cross-reference `determine_next_action()` branches with the Stage 3 diagram
- [ ] Verify skills/ and agents/ listings match actual directory contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)