### PR TITLE
docs: fix bootstrap step count (23 → 38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ agents/                              — Claude Code agent definitions (pipeline
 hooks/           — .claude/settings.json template for projects
 workflows/       — GitHub Actions CI templates
 templates/       — CLAUDE.md.hbs, PROMPT.md, issue-body.md
-bootstrap/       — setup.sh (23-step idempotent project bootstrap)
+bootstrap/       — setup.sh (38-step idempotent project bootstrap)
 install.sh       — curl | bash installer
 research/        — ad-hoc research notes and scratchpad (not committed)
 ```


### PR DESCRIPTION
## Summary
- CLAUDE.md claimed bootstrap had 23 steps; actual count in `bootstrap/setup.sh` is 38 (11 Phase 1 + 27 Phase 2)

Closes #187

## Test plan
- [ ] Count step function calls in `bootstrap/setup.sh` lines 1187-1227 — should be 38

🤖 Generated with [Claude Code](https://claude.com/claude-code)