### PR TITLE
chore: create repo labels and add labeling convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@ research/        — ad-hoc research notes and scratchpad (not committed)
 
 When working through GitHub issues, use `/fix-issue <number>` (or `/fix-issue` for the next open issue). This enforces the full cycle: branch, plan, implement, self-review, PR, wait for merge. One issue at a time — never start the next until the current PR is merged.
 
+### Labels
+
+When creating issues or PRs, apply relevant labels:
+
+- **Component:** `cli`, `bootstrap`, `skills`, `agents`, `hooks`, `ci`
+- **Pipeline:** `pipeline:smelting`, `pipeline:hammering`, `pipeline:tempering`, `pipeline:honing`
+- **Type:** `bug`, `enhancement`, `documentation`, `refactor`, `chore`
+
 After a PR merges, clean up before moving on (see [After a PR is merged](#after-a-pr-is-merged) below).
 
 ## Git Workflow


### PR DESCRIPTION
## Summary
- Created 12 labels on the Forge repo: 6 component (`cli`, `bootstrap`, `skills`, `agents`, `hooks`, `ci`), 4 pipeline (`pipeline:smelting` through `pipeline:honing`), 2 type (`refactor`, `chore`)
- Added labeling convention to CLAUDE.md so labels are applied when creating issues/PRs

Closes #191

## Test plan
- [ ] Run `gh label list` — should show 21 labels (9 default + 12 new)
- [ ] Verify CLAUDE.md has the Labels subsection under Issue Workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)