### PR TITLE
Fix tests clobbering real ~/.forge/config.json

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -5,6 +5,9 @@
 # Guard: FORGE_REPO must be set by the caller.
 : "${FORGE_REPO:?FORGE_REPO must be set before sourcing forge-lib.sh}"
 
+# Config directory (override in tests to avoid clobbering real config)
+FORGE_CONFIG_DIR="${FORGE_CONFIG_DIR:-$HOME/.forge}"
+
 # Colors (can be overridden before sourcing; set to "" to disable in tests)
 RED="${RED-\033[0;31m}"
 GREEN="${GREEN-\033[0;32m}"
@@ -37,7 +40,7 @@ forge_version() {
 require_forge_project() {
     local project_path
     project_path=$(pwd)
-    if [ ! -f "$HOME/.forge/config.json" ]; then
+    if [ ! -f "$FORGE_CONFIG_DIR/config.json" ]; then
         echo -e "${RED}Error:${NC} Not a Forge project."
         echo "  Run ${BOLD}forge init${NC} to bootstrap a new project."
         exit 1
@@ -51,7 +54,7 @@ for name, proj in cfg.get('projects', {}).items():
     if proj.get('path') == sys.argv[2]:
         print('yes')
         break
-" "$HOME/.forge/config.json" "$project_path" 2>/dev/null || true)
+" "$FORGE_CONFIG_DIR/config.json" "$project_path" 2>/dev/null || true)
     if [ "$registered" != "yes" ]; then
         echo -e "${RED}Error:${NC} Not a Forge project."
         echo "  Run ${BOLD}forge init${NC} to bootstrap a new project."

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -57,8 +57,8 @@ load "../helpers/setup"
 
 @test "require_forge_project succeeds when registered in config.json" {
     cd "$TEST_TMPDIR"
-    mkdir -p "$HOME/.forge"
-    cat > "$HOME/.forge/config.json" <<EOF
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
 {
   "projects": {
     "test": {

--- a/tests/helpers/setup.bash
+++ b/tests/helpers/setup.bash
@@ -21,6 +21,9 @@ setup() {
     git -C "$FORGE_REPO" config user.email "forge-test@example.com"
     git -C "$FORGE_REPO" commit --allow-empty -m "init" --quiet
 
+    # Isolate config directory so tests never touch real ~/.forge
+    export FORGE_CONFIG_DIR="$TEST_TMPDIR/.forge"
+
     # Disable colors for cleaner test output
     export RED="" GREEN="" YELLOW="" ORANGE="" BLUE="" BOLD="" DIM="" NC=""
 


### PR DESCRIPTION
## Summary
Introduces `FORGE_CONFIG_DIR` variable (defaulting to `$HOME/.forge`) so `require_forge_project()` uses a configurable path instead of hardcoding `$HOME/.forge/config.json`. Tests set `FORGE_CONFIG_DIR` to a temp directory, preventing test runs from overwriting the real project registry.

Follows the same pattern already used for `FORGE_REPO` and `FORGE_LIB_DIR`.

Closes #211

## Test plan
- [x] All 36 bats tests pass
- [x] Real `~/.forge/config.json` unchanged after test run
- [x] `FORGE_CONFIG_DIR` defaults to `$HOME/.forge` when unset (production behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)