### PR TITLE
Colored message text and spinner during agent execution

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -21,15 +21,48 @@ NC="${NC-\033[0m}"
 # --- Output helpers ---
 
 # Agent-specific messages: [ AGENT ]  message
-agent_msg()  { echo -e "[ ${ORANGE}${1}${NC} ]  $2"; }
-agent_ok()   { echo -e "[ ${ORANGE}${1}${NC} ]  $2 ${GREEN}✓${NC}"; }
-agent_fail() { echo -e "[ ${ORANGE}${1}${NC} ]  ${RED}✗${NC} $2"; }
+agent_msg()  { echo -e "[ ${ORANGE}${1}${NC} ]  ${DIM}$2${NC}"; }
+agent_ok()   { echo -e "[ ${ORANGE}${1}${NC} ]  ${GREEN}$2 ✓${NC}"; }
+agent_fail() { echo -e "[ ${ORANGE}${1}${NC} ]  ${RED}✗ $2${NC}"; }
 
 # General messages (no agent name)
-forge_info() { echo -e "${DIM}▸${NC} $1"; }
-forge_ok()   { echo -e "${GREEN}✓${NC} $1"; }
-forge_fail() { echo -e "${RED}✗${NC} $1"; }
-forge_warn() { echo -e "${YELLOW}!${NC} $1"; }
+forge_info() { echo -e "${DIM}▸ $1${NC}"; }
+forge_ok()   { echo -e "${GREEN}✓ $1${NC}"; }
+forge_fail() { echo -e "${RED}✗ $1${NC}"; }
+forge_warn() { echo -e "${YELLOW}! $1${NC}"; }
+
+# --- Spinner ---
+
+_FORGE_SPINNER_PID=""
+
+_forge_spinner_start() {
+    local msg="${1:-Working...}"
+    # Skip spinner if not a terminal or colors are disabled (test mode)
+    if [[ ! -t 1 ]] || [[ -z "${DIM}${NC}" ]]; then
+        _FORGE_SPINNER_PID=""
+        return
+    fi
+    (
+        set +e
+        local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+        local i=0
+        while true; do
+            printf '\r  %b%s %s%b' "$DIM" "${frames[$i]}" "$msg" "$NC"
+            i=$(( (i + 1) % ${#frames[@]} ))
+            sleep 0.1
+        done
+    ) &
+    _FORGE_SPINNER_PID=$!
+}
+
+_forge_spinner_stop() {
+    if [[ -n "${_FORGE_SPINNER_PID:-}" ]]; then
+        kill "$_FORGE_SPINNER_PID" 2>/dev/null || true
+        wait "$_FORGE_SPINNER_PID" 2>/dev/null || true
+        printf '\r\033[K'
+        _FORGE_SPINNER_PID=""
+    fi
+}
 
 # --- Shared helpers ---
 
@@ -173,7 +206,16 @@ run_forge_agent() {
     [ -n "$prompt" ] && cmd+=(-p "$prompt")
     [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
 
-    "${cmd[@]}"
+    # Start spinner for headless agents (those with -p flag)
+    if [ -n "$prompt" ]; then
+        _forge_spinner_start
+    fi
+
+    local exit_code=0
+    "${cmd[@]}" || exit_code=$?
+
+    _forge_spinner_stop
+    return "$exit_code"
 }
 
 # --- Issue query helpers ---

--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Exit cleanly on CTRL+C (exit code 130 = 128 + SIGINT)
-trap 'echo ""; echo -e "${RED}✗${NC} Interrupted."; exit 130' INT
-
 FORGE_REPO="$HOME/.forge/repo"
 
 if [ ! -d "$FORGE_REPO" ]; then
@@ -16,6 +13,9 @@ fi
 FORGE_LIB_DIR="${FORGE_LIB_DIR:-"$FORGE_REPO/bin"}"
 # shellcheck source=bin/forge-lib.sh
 source "${FORGE_LIB_DIR}/forge-lib.sh"
+
+# Exit cleanly on CTRL+C (exit code 130 = 128 + SIGINT)
+trap '_forge_spinner_stop; echo ""; echo -e "${RED}✗${NC} Interrupted."; exit 130' INT
 
 show_banner() {
     local variant="${1:-main}"


### PR DESCRIPTION
## Summary
Extends the output helpers from #206 with colored message text and a braille spinner:

- `agent_msg` — DIM text (muted, in-progress feel)
- `agent_ok` — GREEN text + checkmark
- `agent_fail` — RED text + X
- `forge_info/ok/fail/warn` — color extends to cover the full message

Adds a braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) that displays during headless agent execution, providing visual feedback during the connection/startup delay. Automatically skipped in non-TTY environments and tests.

Closes #212

## Test plan
- [x] All 36 bats tests pass
- [ ] Run `forge cast` — verify colored text and spinner during agent startup
- [ ] Press CTRL+C during spinner — verify clean exit with no orphaned process

🤖 Generated with [Claude Code](https://claude.com/claude-code)