### PR TITLE
Codify already-addressed handling in stoke agents

### DIFF
--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -131,6 +131,8 @@ Launch a Plan agent with the research findings and issue requirements. The Plan 
 
 Review what the Plan agent returns. You are the Blacksmith — the Plan agent is a tool, not the decision-maker. Adjust, override, or expand its output based on your research findings. The implementation plan must be yours, not a pass-through. Document your decisions in the ledger.
 
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, this is a valid outcome — not a failure. Skip Steps 5 through 9 (no `status:hammering`, no branch, no commits). Go directly to Step 10 and post a ledger documenting what was verified and why no changes are needed. Include `**Status: Already Addressed**` in the ledger so downstream agents can detect this case. Then mark `status:hammered` (skip the `git push` in Step 11 — only update the label, removing `status:ready` or `status:rework` instead of `status:hammering`).
+
 ### 5. Set Status
 
 Before starting implementation, transition the issue label:

--- a/plugin/agents/auto-proof-master.md
+++ b/plugin/agents/auto-proof-master.md
@@ -70,7 +70,7 @@ If a `status:proved` issue is found, a PR was previously opened but the merge di
 1. Find the PR: `gh pr list --state all --search "Closes #<N>" --json number,state --jq '.[0]'`
 2. If the PR is **merged** — the issue should have auto-closed. Close it now: `gh issue close <N> --reason completed`
 3. If the PR is **open** — resume from Step 15 (Merge). Run the pre-merge gate checks first.
-4. If **no PR exists** — escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
+4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
 
 After recovery, exit. Do not continue to the normal workflow.
 
@@ -82,6 +82,8 @@ Find the linked branch:
 ```bash
 gh issue develop <N> --list
 ```
+
+**Already-addressed early exit:** If no branch exists and the Blacksmith and Temperer ledgers both contain `**Status: Already Addressed**`, this issue needs no PR. Verify each acceptance criterion one final time against the codebase, post the Proof-Master ledger (Step 16), remove the `status:tempered` label, close the issue (`gh issue close <N> --reason completed`), and stop. Do not proceed to Step 2.
 
 ### 2. Set Status
 
@@ -189,6 +191,8 @@ gh issue comment <N> --body "**[Proof-Master]** Escalating to human review.
 Then stop — do not proceed.
 
 ### 10. Open PR
+
+**Already-addressed case:** This should have been caught at Step 1 (early exit). If it reaches here, check whether a branch exists (`gh issue develop <N> --list`). If no branch, remove `status:proving`, post the Proof-Master ledger (Step 16), close the issue (`gh issue close <N> --reason completed`), and stop.
 
 ```bash
 gh issue edit <N> --remove-label "status:proving" --add-label "status:proved"

--- a/plugin/agents/auto-temperer.md
+++ b/plugin/agents/auto-temperer.md
@@ -69,6 +69,8 @@ Find the linked branch:
 gh issue develop <N> --list
 ```
 
+If no branch is found, this may be an already-addressed case where the Blacksmith determined no code changes were needed. Proceed with the review — base your assessment on the codebase itself, not a diff.
+
 Count completed rework cycles to calibrate your review:
 ```bash
 gh api repos/{owner}/{repo}/issues/<N>/comments --jq '[.[] | select(.body | test("^✅\\s*\\*\\*\\[Temperer\\]"))] | length'
@@ -123,6 +125,8 @@ Review what the Plan agent returns. You are the Temperer — the Plan agent is a
 **ESCALATE** if:
 - Requirements are ambiguous and correctness can't be determined
 - Implementation reveals a fundamental design problem
+
+**No-code-change reviews:** When the Blacksmith's ledger contains `**Status: Already Addressed**`, do not simply trust the ledger. Independently verify each acceptance criterion by reading the codebase (skip any diff-based review steps — there is no branch to diff). You may still APPROVE, REWORK, or ESCALATE based on your own findings. Post your own ledger documenting your independent verification, including `**Status: Already Addressed**` if you agree.
 
 ### 6a. On APPROVE
 

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -150,6 +150,8 @@ Present your implementation plan to the user:
 
 **Get explicit user confirmation before implementing.**
 
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, present this finding to the user. If confirmed, skip implementation — post a ledger documenting what was verified and why no changes are needed, including `**Status: Already Addressed**` so downstream agents can detect this case. Then mark `status:hammered` (removing `status:ready` or `status:rework` directly, since `status:hammering` was never set).
+
 ### 6. Set Status
 
 Before starting implementation, transition the issue label:

--- a/plugin/agents/proof-master.md
+++ b/plugin/agents/proof-master.md
@@ -66,7 +66,7 @@ If a `status:proved` issue is found, a PR was previously opened but the merge di
 1. Find the PR: `gh pr list --state all --search "Closes #<N>" --json number,state --jq '.[0]'`
 2. If the PR is **merged** — the issue should have auto-closed. Close it now: `gh issue close <N> --reason completed`
 3. If the PR is **open** — resume from Step 15 (Merge). Run the pre-merge gate checks first.
-4. If **no PR exists** — escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
+4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
 
 After recovery, exit. Do not continue to the normal workflow.
 
@@ -78,6 +78,8 @@ Find the linked branch:
 ```bash
 gh issue develop <N> --list
 ```
+
+**Already-addressed early exit:** If no branch exists and the Blacksmith and Temperer ledgers both contain `**Status: Already Addressed**`, this issue needs no PR. Verify each acceptance criterion one final time against the codebase, post the Proof-Master ledger (Step 16), remove the `status:tempered` label, close the issue (`gh issue close <N> --reason completed`), and stop. Do not proceed to Step 2.
 
 ### 2. Set Status
 
@@ -193,6 +195,8 @@ gh issue comment <N> --body "**[Proof-Master]** Escalating to human review.
 Then stop — do not proceed.
 
 ### 10. Open PR
+
+**Already-addressed case:** This should have been caught at Step 1 (early exit). If it reaches here, check whether a branch exists (`gh issue develop <N> --list`). If no branch, remove `status:proving`, post the Proof-Master ledger (Step 16), close the issue (`gh issue close <N> --reason completed`), and stop.
 
 ```bash
 gh issue edit <N> --remove-label "status:proving" --add-label "status:proved"

--- a/plugin/agents/temperer.md
+++ b/plugin/agents/temperer.md
@@ -65,6 +65,8 @@ Find the linked branch:
 gh issue develop <N> --list
 ```
 
+If no branch is found, this may be an already-addressed case where the Blacksmith determined no code changes were needed. Proceed with the review — base your assessment on the codebase itself, not a diff.
+
 Count completed rework cycles to calibrate your review:
 ```bash
 gh api repos/{owner}/{repo}/issues/<N>/comments --jq '[.[] | select(.body | test("^✅\\s*\\*\\*\\[Temperer\\]"))] | length'
@@ -131,6 +133,8 @@ Iterate based on user feedback. **Get explicit user confirmation on the verdict.
 **ESCALATE** if:
 - Requirements are ambiguous and correctness can't be determined
 - Implementation reveals a fundamental design problem
+
+**No-code-change reviews:** When the Blacksmith's ledger contains `**Status: Already Addressed**`, do not simply trust the ledger. Independently verify each acceptance criterion by reading the codebase (skip any diff-based review steps — there is no branch to diff). Present your findings to the user. Post your own ledger documenting your independent verification, including `**Status: Already Addressed**` if you agree.
 
 ### 7a. On APPROVE
 


### PR DESCRIPTION
## Summary
Adds explicit guidance to all six craftsman agents (auto + interactive) for handling issues whose acceptance criteria are already satisfied by prior work.

- **Blacksmith**: detects already-addressed during Plan & Decide, posts ledger with `**Status: Already Addressed**` marker, skips implementation
- **Temperer**: recognizes no-branch case, skips diff-based review, independently verifies criteria against codebase, propagates the marker in its own ledger
- **Proof-Master**: early exit at Step 1 when no branch exists and both upstream ledgers contain the marker — verifies criteria, posts ledger, closes issue directly (no PR needed). Label cleanup included.

Closes #213

## Test plan
- [x] All 36 bats tests pass
- [ ] Run `forge cast` on a project where an issue is already satisfied — verify the three agents pass it through with ledgers and close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)