### PR TITLE
Consistent label ordering and cleanup on close

### DIFF
--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -131,7 +131,7 @@ Launch a Plan agent with the research findings and issue requirements. The Plan 
 
 Review what the Plan agent returns. You are the Blacksmith — the Plan agent is a tool, not the decision-maker. Adjust, override, or expand its output based on your research findings. The implementation plan must be yours, not a pass-through. Document your decisions in the ledger.
 
-**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, this is a valid outcome — not a failure. Skip Steps 5 through 9 (no `status:hammering`, no branch, no commits). Go directly to Step 10 and post a ledger documenting what was verified and why no changes are needed. Include `**Status: Already Addressed**` in the ledger so downstream agents can detect this case. Then mark `status:hammered` (skip the `git push` in Step 11 — only update the label, removing `status:ready` or `status:rework` instead of `status:hammering`).
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, this is a valid outcome — not a failure. Skip Steps 5 through 9 (no `status:hammering`, no branch, no commits). Mark `status:hammered` first (skip the `git push` in Step 10 — only update the label, removing `status:ready` or `status:rework` instead of `status:hammering`). Then go to Step 11 and post a ledger documenting what was verified and why no changes are needed. Include `**Status: Already Addressed**` in the ledger so downstream agents can detect this case.
 
 ### 5. Set Status
 
@@ -188,7 +188,14 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '.[] | select(.body | test(
 gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <original body>"
 ```
 
-### 10. Post Ledger Comment
+### 10. Push & Update Status
+
+```bash
+git push -u origin HEAD
+gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
+```
+
+### 11. Post Ledger Comment
 
 **First pass:**
 ```bash
@@ -232,13 +239,6 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 *Posted by the Forge Blacksmith.*"
 ```
 
-### 11. Push & Update Status
-
-```bash
-git push -u origin HEAD
-gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
-```
-
 ## Rules
 
 - **Never substitute a different issue** than the one you were assigned in the prompt.
@@ -248,4 +248,5 @@ gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered
 - **Never ask questions.** You are running headless. Make decisions and document them in the ledger.
 - **Always launch research agents** — never skip research.
 - **Always launch the Plan agent** — never plan the implementation yourself.
+- **Action before ledger.** Push and update the status label before posting the ledger comment.
 - **Max rework cycles:** If sent back 5 times total, escalate to `agent:needs-human`.

--- a/plugin/agents/auto-proof-master.md
+++ b/plugin/agents/auto-proof-master.md
@@ -68,9 +68,9 @@ gh issue list --state open --label "status:proved" --label "ai-generated" --json
 
 If a `status:proved` issue is found, a PR was previously opened but the merge did not complete. **Skip directly to recovery:**
 1. Find the PR: `gh pr list --state all --search "Closes #<N>" --json number,state --jq '.[0]'`
-2. If the PR is **merged** — the issue should have auto-closed. Close it now: `gh issue close <N> --reason completed`
+2. If the PR is **merged** — the issue should have auto-closed. Remove status labels and close it: `gh issue edit <N> --remove-label "status:proved" || true` then `gh issue close <N> --reason completed`
 3. If the PR is **open** — resume from Step 15 (Merge). Run the pre-merge gate checks first.
-4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
+4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, remove status labels (`gh issue edit <N> --remove-label "status:proved" || true`), and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
 
 After recovery, exit. Do not continue to the normal workflow.
 
@@ -323,6 +323,7 @@ Pre-merge gate — verify ALL of the following before merging:
 
 ```bash
 gh pr merge <pr_number> --squash --delete-branch
+gh issue edit <N> --remove-label "status:proved" || true
 ```
 
 If the merge fails (e.g., branch protection checks not satisfied), escalate:

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -150,7 +150,7 @@ Present your implementation plan to the user:
 
 **Get explicit user confirmation before implementing.**
 
-**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, present this finding to the user. If confirmed, skip implementation — post a ledger documenting what was verified and why no changes are needed, including `**Status: Already Addressed**` so downstream agents can detect this case. Then mark `status:hammered` (removing `status:ready` or `status:rework` directly, since `status:hammering` was never set).
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, present this finding to the user. If confirmed, mark `status:hammered` first (removing `status:ready` or `status:rework` directly, since `status:hammering` was never set). Then post a ledger documenting what was verified and why no changes are needed, including `**Status: Already Addressed**` so downstream agents can detect this case.
 
 ### 6. Set Status
 
@@ -207,7 +207,14 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '.[] | select(.body | test(
 gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <original body>"
 ```
 
-### 11. Post Ledger Comment
+### 11. Push & Update Status
+
+```bash
+git push -u origin HEAD
+gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
+```
+
+### 12. Post Ledger Comment
 
 **First pass:**
 ```bash
@@ -251,13 +258,6 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 *Posted by the Forge Blacksmith.*"
 ```
 
-### 12. Push & Update Status
-
-```bash
-git push -u origin HEAD
-gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
-```
-
 ## Rules
 
 - **One issue at a time.** Never work on multiple issues.
@@ -266,4 +266,5 @@ gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered
 - **Always confer with the user** on the plan before implementing.
 - **Always launch research agents** — never skip research.
 - **Always launch the Plan agent** — never plan the implementation yourself.
+- **Action before ledger.** Push and update the status label before posting the ledger comment.
 - **Max rework cycles:** If sent back 5 times total, escalate to `agent:needs-human`.

--- a/plugin/agents/proof-master.md
+++ b/plugin/agents/proof-master.md
@@ -64,9 +64,9 @@ gh issue list --state open --label "status:proved" --label "ai-generated" --json
 
 If a `status:proved` issue is found, a PR was previously opened but the merge did not complete. **Skip directly to recovery:**
 1. Find the PR: `gh pr list --state all --search "Closes #<N>" --json number,state --jq '.[0]'`
-2. If the PR is **merged** — the issue should have auto-closed. Close it now: `gh issue close <N> --reason completed`
+2. If the PR is **merged** — the issue should have auto-closed. Remove status labels and close it: `gh issue edit <N> --remove-label "status:proved" || true` then `gh issue close <N> --reason completed`
 3. If the PR is **open** — resume from Step 15 (Merge). Run the pre-merge gate checks first.
-4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
+4. If **no PR exists** — read the Blacksmith and Temperer ledger comments. If both indicate the issue was already addressed (no code changes needed), verify acceptance criteria one final time against the codebase, post the Proof-Master ledger, remove status labels (`gh issue edit <N> --remove-label "status:proved" || true`), and close the issue: `gh issue close <N> --reason completed`. If the ledgers do not indicate already-addressed, escalate: `gh issue edit <N> --remove-label "status:proved" --add-label "agent:needs-human"`
 
 After recovery, exit. Do not continue to the normal workflow.
 
@@ -330,6 +330,7 @@ Pre-merge gate — verify ALL of the following before merging:
 **Get explicit user confirmation before merging.** Present the pre-merge gate checklist results and wait for approval.
 ```bash
 gh pr merge <pr_number> --squash --delete-branch
+gh issue edit <N> --remove-label "status:proved" || true
 ```
 
 Clean up locally:


### PR DESCRIPTION
## Summary
- Blacksmith: swaps push+label step before ledger comment to match Temperer's "action before ledger" convention. Adds the rule explicitly.
- Proof-Master: removes `status:proved` label after merge and in recovery close paths so closed issues don't carry stale status labels.
- Already-addressed paths updated to follow action-before-ledger ordering.

Closes #218

## Test plan
- [x] All 36 bats tests pass
- [ ] Run `forge cast` — verify Blacksmith sets label before posting ledger
- [ ] After merge, verify closed issues no longer have `status:proved` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)