### PR TITLE
Refiner applies scope labels to implementation issues

### DIFF
--- a/plugin/agents/auto-refiner.md
+++ b/plugin/agents/auto-refiner.md
@@ -82,12 +82,15 @@ Check if the milestone already exists first.
 
 ### 5. Create GitHub Issues
 
+Classify each issue by scope. Add one or more scope labels: `scope:ui`, `scope:api`, `scope:data`, `scope:auth`, `scope:infra`.
+
 ```bash
 gh issue create \
     --title "<issue title>" \
     --body "<issue body>" \
     --label "ai-generated" \
     --label "status:ready" \
+    --label "scope:<scope>" \
     --milestone "<milestone title>"
 ```
 
@@ -141,6 +144,6 @@ gh issue close <ingot-issue-number>
 - **Never ask questions.** You are running headless. Make scope decisions and document them.
 - **Always launch research agents** — never skip research.
 - **Always launch the Plan agent** — never plan the breakdown yourself.
-- Every issue must have `ai-generated` and `status:ready` labels.
+- Every issue must have `ai-generated`, `status:ready`, and at least one `scope:*` label.
 - Process one ingot per invocation.
 - Check for existing issues/milestones before creating to ensure idempotency.

--- a/plugin/agents/refiner.md
+++ b/plugin/agents/refiner.md
@@ -87,7 +87,7 @@ Check if the milestone already exists first.
 
 ### 6. Create GitHub Issues
 
-After user approval, create issues with `ai-generated` and `status:ready` labels:
+After user approval, create issues with `ai-generated`, `status:ready`, and scope labels. Classify each issue by scope — add one or more of: `scope:ui`, `scope:api`, `scope:data`, `scope:auth`, `scope:infra`.
 
 ```bash
 gh issue create \
@@ -95,6 +95,7 @@ gh issue create \
     --body "<issue body>" \
     --label "ai-generated" \
     --label "status:ready" \
+    --label "scope:<scope>" \
     --milestone "<milestone title>"
 ```
 
@@ -148,6 +149,6 @@ gh issue close <ingot-issue-number>
 - **Always confer with the user** before filing issues. The user approves the breakdown.
 - **Always launch research agents** — never skip research.
 - **Always launch the Plan agent** — never plan the breakdown yourself.
-- Every issue must have `ai-generated` and `status:ready` labels.
+- Every issue must have `ai-generated`, `status:ready`, and at least one `scope:*` label.
 - Process one ingot per invocation.
 - Check for existing issues/milestones before creating to ensure idempotency.


### PR DESCRIPTION
## Summary
Adds scope label classification to both refiner agent definitions. Each implementation issue now gets one or more `scope:*` labels (`scope:ui`, `scope:api`, `scope:data`, `scope:auth`, `scope:infra`) during creation, and the Rules section requires at least one.

Closes #219

## Test plan
- [x] All 36 bats tests pass
- [ ] Run `forge refine` — verify created issues have scope labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)