### PR TITLE
Release v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "name": "Allan Mobley Jr."
   },
   "metadata": {
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugin",
       "description": "Autonomous Next.js development pipeline with craftsman agents",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "repository": "https://github.com/allan-mobley-jr/forge",
       "keywords": ["nextjs", "vercel", "autonomous", "agents", "development"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-03-30
+
+### Added
+- Named session history with interactive arrow-key picker for all commands
+- Milestone-scoped session resume (CLI resumes context on crash/relaunch)
+- INGOT.md as persistent codebase artifact (materialized from ingot by first Blacksmith issue)
+- Smelter handles Vercel environment setup on first run (production + staging environments, env vars, Neon database branching)
+- CLI session helpers: `pick_session`, `list_sessions`, `set_session`, `get_session`, `clear_session`, `clear_all_sessions`
+- `find_issue_for_temper_recovery` for status:tempered PR/merge recovery
+- `sessions` field in bootstrap project config
+
+### Changed
+- Rework pipeline from 7 agents to 3 core + 3 post-cycle agents (Smelter/Blacksmith/Temperer + Proof-Master/Honer/Scribe)
+- Smelter absorbs Refiner — plans and creates implementation issues in one session
+- Temperer absorbs Proof-Master PR/merge — lean review with E2E tests, opens PR, squash-merges
+- Proof-Master rewritten as release manager — analyzes commits, determines semver, builds changelog, creates GitHub releases
+- Honer files implementation issues directly instead of ingots (milestone-grouped for larger gaps)
+- Blacksmith reads INGOT.md for architectural context before implementation
+- Blacksmith self-review proportional to change complexity (mandatory for substantial, optional for small)
+- Enriched ledgers with Key Decisions and Approaches Rejected sections
+- Stoke/cast loop simplified to 3-agent state machine with milestone-scoped session resume
+- Cast post-cycle order: Honer → Scribe → Proof-Master (was Proof-Master first)
+- Cast loop resilient to interruption via GitHub history check
+- Issue ownership enforcement on all agents (auto: skip non-owner, interactive: flag + approve)
+- `type:ingot` label scoped to one-time Smelter specification
+
+### Removed
+- Refiner agent (merged into Smelter)
+- `forge refine` / `forge auto-refine` commands
+- `status:proving` and `status:proved` labels (24 → 22)
+- Copilot review workflow from all agents
+- Vercel deployment from Proof-Master
+- Proof-Master ledger comment (release notes and changelog are its artifacts)
+- `find_issue_for_proof` and `find_unprocessed_ingots` CLI functions
+- `forge_status_transition` CLI output
+
 ## [0.1.3] - 2026-03-28
 
 ### Added
@@ -52,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `forge deploy` for human-controlled production releases
 - `curl | bash` installer with Vercel plugin and Playwright MCP setup
 
+[0.2.0]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.2.0
 [0.1.3]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.1.3
 [0.1.2]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.1.2
 [0.1.1]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ plugin/          — Claude Code plugin (only this gets cached)
     auto-blacksmith.md — Auto-Blacksmith: headless implementation
     temperer.md      — Temperer: interactive review + PR + merge
     auto-temperer.md — Auto-Temperer: headless review + PR + merge
-    proof-master.md  — Proof-Master: interactive releases + deploy
-    auto-proof-master.md — Auto-Proof-Master: headless releases + deploy
+    proof-master.md  — Proof-Master: interactive releases + versioning
+    auto-proof-master.md — Auto-Proof-Master: headless releases + versioning
     honer.md         — Honer: interactive bug triage / audit
     auto-honer.md    — Auto-Honer: headless bug triage / audit
     scribe.md        — Scribe: interactive doc audit / wiki

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Forge uses a medieval forge metaphor. Three core craftsmen — each a Claude Cod
 | **Smelter** | `forge smelt` | Researches, plans, and creates sequenced implementation issues. On first run, produces the project ingot (INGOT.md). |
 | **Blacksmith** | `forge hammer` | Implements the lowest open issue on a feature branch. Reads INGOT.md for architectural context. |
 | **Temperer** | `forge temper` | Reviews the Blacksmith's work with E2E tests. Approves and merges, or sends back for rework. |
-| **Proof-Master** | `forge proof` | Checks for unreleased work on main. Creates versioned releases with changelog. Manages Vercel deployment. |
+| **Proof-Master** | `forge proof` | Checks for unreleased work on main. Creates versioned releases with changelog. |
 | **Honer** | `forge hone` | Triages bugs or audits the codebase. Files implementation issues for the Blacksmith. |
 | **Scribe** | `forge scribe` | Audits documentation and maintains the GitHub Wiki. Files doc issues for the Blacksmith. |
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Autonomous Next.js development pipeline with craftsman agents (Smelter, Blacksmith, Temperer, Proof-Master, Honer, Scribe)",
   "author": {
     "name": "Allan Mobley Jr."


### PR DESCRIPTION
## Release v0.2.0

### Added
- Named session history with interactive arrow-key picker for all commands
- Milestone-scoped session resume (CLI resumes context on crash/relaunch)
- INGOT.md as persistent codebase artifact (materialized from ingot by first Blacksmith issue)
- Smelter handles Vercel environment setup on first run (production + staging environments, env vars, Neon database branching)
- CLI session helpers: `pick_session`, `list_sessions`, `set_session`, `get_session`, `clear_session`, `clear_all_sessions`
- `find_issue_for_temper_recovery` for status:tempered PR/merge recovery
- `sessions` field in bootstrap project config

### Changed
- Rework pipeline from 7 agents to 3 core + 3 post-cycle agents (Smelter/Blacksmith/Temperer + Proof-Master/Honer/Scribe)
- Smelter absorbs Refiner — plans and creates implementation issues in one session
- Temperer absorbs Proof-Master PR/merge — lean review with E2E tests, opens PR, squash-merges
- Proof-Master rewritten as release manager — analyzes commits, determines semver, builds changelog, creates GitHub releases
- Honer files implementation issues directly instead of ingots (milestone-grouped for larger gaps)
- Blacksmith reads INGOT.md for architectural context before implementation
- Blacksmith self-review proportional to change complexity (mandatory for substantial, optional for small)
- Enriched ledgers with Key Decisions and Approaches Rejected sections
- Stoke/cast loop simplified to 3-agent state machine with milestone-scoped session resume
- Cast post-cycle order: Honer → Scribe → Proof-Master (was Proof-Master first)
- Cast loop resilient to interruption via GitHub history check
- Issue ownership enforcement on all agents (auto: skip non-owner, interactive: flag + approve)
- `type:ingot` label scoped to one-time Smelter specification

### Removed
- Refiner agent (merged into Smelter)
- `forge refine` / `forge auto-refine` commands
- `status:proving` and `status:proved` labels (24 → 22)
- Copilot review workflow from all agents
- Vercel deployment from Proof-Master
- Proof-Master ledger comment (release notes and changelog are its artifacts)
- `find_issue_for_proof` and `find_unprocessed_ingots` CLI functions
- `forge_status_transition` CLI output

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)