### PR TITLE
fix: pass --allowedTools on session resume

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -511,6 +511,7 @@ run_forge_agent() {
         # Resume an existing session by UUID
         cmd=(claude --resume "$resume_session")
         [ -n "$prompt" ] && cmd+=(-p "$prompt")
+        [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     else
         # Start a new session
         cmd=(claude --agent "forge:${agent_name_lower}")


### PR DESCRIPTION
## Summary

The resume branch of `run_forge_agent()` was missing `--allowedTools`, causing every tool call in resumed sessions to require manual approval. In headless mode (`-p`), this creates an infinite permission-denied loop since no human can approve. This caused the Temperer to hang for 2+ hours on Deadbolt issue #33 during `forge cast`.

One-line fix: add `[ -n "$tools" ] && cmd+=(--allowedTools "$tools")` to the resume branch.

Closes #247

## Test plan

- [ ] 42 existing tests pass
- [ ] `forge cast` resumes sessions without permission denial loops
- [ ] Resumed Temperer can execute `gh issue edit` and `gh issue comment` in headless mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)