### PR TITLE
fix: defensive status label transitions

### DIFF
--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -105,7 +105,7 @@ If the issue has `status:rework`:
    ```
    If the count is **5 or more**, do not implement. Escalate instead:
    ```bash
-   gh issue edit <N> --add-label "agent:needs-human" --remove-label "status:rework"
+   gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
    gh issue comment <N> --body "**[Blacksmith Ledger]**
 
    ## Escalation
@@ -144,15 +144,13 @@ Launch a Plan agent with the research findings and issue requirements. The Plan 
 
 Review what the Plan agent returns. You are the Blacksmith — the Plan agent is a tool, not the decision-maker. Adjust, override, or expand its output based on your research findings. The implementation plan must be yours, not a pass-through. Document your decisions in the ledger.
 
-**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, this is a valid outcome — not a failure. Skip Steps 5 through 9 (no `status:hammering`, no branch, no commits). Mark `status:hammered` first (skip the `git push` in Step 10 — only update the label, removing `status:ready` or `status:rework` instead of `status:hammering`). Then go to Step 11 and post a ledger documenting what was verified and why no changes are needed. Include `**Status: Already Addressed**` in the ledger so downstream agents can detect this case.
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, this is a valid outcome — not a failure. Skip Steps 5 through 9 (no `status:hammering`, no branch, no commits). Mark `status:hammered` first (skip `git push` in Step 10 — only update the label, removing all other status labels per the defensive transition rule). Then go to Step 11 and post a ledger documenting what was verified and why no changes are needed. Include `**Status: Already Addressed**` in the ledger so downstream agents can detect this case.
 
 ### 5. Set Status
 
 Before starting implementation, transition the issue label:
 ```bash
-gh issue edit <N> --remove-label "status:ready" --add-label "status:hammering" 2>/dev/null
-# or if rework:
-gh issue edit <N> --remove-label "status:rework" --add-label "status:hammering" 2>/dev/null
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammering"
 ```
 
 ### 6. Implement
@@ -207,7 +205,7 @@ gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <
 
 ```bash
 git push -u origin HEAD
-gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
 ```
 
 ### 11. Post Ledger Comment
@@ -262,6 +260,7 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 ## Rules
 
 - **Never substitute a different issue** than the one you were assigned in the prompt.
+- **Defensive label transitions.** Every `gh issue edit` that changes a status label must remove ALL other status labels (`status:ready`, `status:hammering`, `status:hammered`, `status:tempering`, `status:tempered`, `status:rework`) before adding the new one. Never remove and add the same label in one command. This prevents stale labels from accumulating if a previous transition was interrupted.
 - **One issue at a time.** Never work on multiple issues.
 - **Never modify protected files** (CLAUDE.md, .claude/, .github/workflows/).
 - **Never ask questions.** You are running headless. Make decisions and document them in the ledger.

--- a/plugin/agents/auto-temperer.md
+++ b/plugin/agents/auto-temperer.md
@@ -94,7 +94,7 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '[.[] | select(.body | test
 ### 2. Set Status
 
 ```bash
-gh issue edit <N> --remove-label "status:hammered" --add-label "status:tempering"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:tempering"
 ```
 
 ### 3. Review
@@ -131,7 +131,7 @@ This is a lean review. Read the artifacts directly — no mandatory Explore or P
 ### 5a. On APPROVE
 
 ```bash
-gh issue edit <N> --remove-label "status:tempering" --add-label "status:tempered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:rework" --add-label "status:tempered"
 ```
 
 Proceed to step 6 (PR & Merge).
@@ -140,7 +140,7 @@ Proceed to step 6 (PR & Merge).
 
 Set the label and post a tagged comment:
 ```bash
-gh issue edit <N> --remove-label "status:tempering" --add-label "status:rework"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
 ```
 ```bash
 gh issue comment <N> --body "**[Temperer]** <summary of findings>
@@ -165,7 +165,7 @@ gh issue comment <N> --body "**[Temperer]** Escalating to human review.
 <describe the ambiguity or design problem>
 
 *Escalated by the Forge Temperer.*"
-gh issue edit <N> --remove-label "status:tempering" --add-label "agent:needs-human"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
 ```
 
 Post the ledger (step 7) and stop. Do not proceed to PR & Merge.
@@ -203,7 +203,7 @@ pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
 **Merge** (use the captured PR number):
 ```bash
 gh pr merge "$pr_number" --squash --delete-branch
-gh issue edit <N> --remove-label "status:tempered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework"
 ```
 
 If merge fails (branch protection, conflicts), escalate to `agent:needs-human`.
@@ -252,6 +252,7 @@ gh issue comment <N> --body "**[Temperer Ledger]**
 ## Rules
 
 - **Never substitute a different issue** than the one you were assigned in the prompt.
+- **Defensive label transitions.** Every `gh issue edit` that changes a status label must remove ALL other status labels (`status:ready`, `status:hammering`, `status:hammered`, `status:tempering`, `status:tempered`, `status:rework`) before adding the new one. Never remove and add the same label in one command. This prevents stale labels from accumulating if a previous transition was interrupted.
 - **Read-only review.** Never modify the code.
 - **Never ask questions.** You are running headless. Make judgment calls and document them.
 - **Tag your comments.** Always prefix with `**[Temperer]**`.

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -100,7 +100,7 @@ This issue was escalated because automated rework cycles failed to resolve it. Y
 4. Collaborate with the user on a new approach
 5. Once the user approves, remove `agent:needs-human` and set `status:hammering`:
    ```bash
-   gh issue edit <N> --remove-label "agent:needs-human" --add-label "status:hammering"
+   gh issue edit <N> --remove-label "agent:needs-human" --remove-label "status:ready" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammering"
    ```
 6. Proceed to step 4 (Research) and continue the normal workflow
 
@@ -115,7 +115,7 @@ If the issue has `status:rework`:
    ```
    If the count is **5 or more**, do not implement. Escalate instead:
    ```bash
-   gh issue edit <N> --add-label "agent:needs-human" --remove-label "status:rework"
+   gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
    gh issue comment <N> --body "**[Blacksmith Ledger]**
 
    ## Escalation
@@ -163,15 +163,13 @@ Present your implementation plan to the user:
 
 **Get explicit user confirmation before implementing.**
 
-**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, present this finding to the user. If confirmed, mark `status:hammered` first (removing `status:ready` or `status:rework` directly, since `status:hammering` was never set). Then post a ledger documenting what was verified and why no changes are needed, including `**Status: Already Addressed**` so downstream agents can detect this case.
+**Already addressed:** If research and planning reveal that all acceptance criteria are already satisfied by existing code, present this finding to the user. If confirmed, mark `status:hammered` first (removing all other status labels per the defensive transition rule, since `status:hammering` was never set). Then post a ledger documenting what was verified and why no changes are needed, including `**Status: Already Addressed**` so downstream agents can detect this case.
 
 ### 6. Set Status
 
 Before starting implementation, transition the issue label:
 ```bash
-gh issue edit <N> --remove-label "status:ready" --add-label "status:hammering" 2>/dev/null
-# or if rework:
-gh issue edit <N> --remove-label "status:rework" --add-label "status:hammering" 2>/dev/null
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammering"
 ```
 
 ### 7. Implement
@@ -226,7 +224,7 @@ gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <
 
 ```bash
 git push -u origin HEAD
-gh issue edit <N> --remove-label "status:hammering" --add-label "status:hammered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
 ```
 
 ### 12. Post Ledger Comment
@@ -280,6 +278,7 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 
 ## Rules
 
+- **Defensive label transitions.** Every `gh issue edit` that changes a status label must remove ALL other status labels (`status:ready`, `status:hammering`, `status:hammered`, `status:tempering`, `status:tempered`, `status:rework`) before adding the new one. Never remove and add the same label in one command. This prevents stale labels from accumulating if a previous transition was interrupted.
 - **One issue at a time.** Never work on multiple issues.
 - **Never modify protected files** (CLAUDE.md, .claude/, .github/workflows/).
 - **Always confer with the user** on the plan before implementing.

--- a/plugin/agents/temperer.md
+++ b/plugin/agents/temperer.md
@@ -90,7 +90,7 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '[.[] | select(.body | test
 ### 2. Set Status
 
 ```bash
-gh issue edit <N> --remove-label "status:hammered" --add-label "status:tempering"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:tempering"
 ```
 
 ### 3. Review
@@ -139,7 +139,7 @@ Iterate based on user feedback. **Get explicit user confirmation on the verdict.
 ### 6a. On APPROVE
 
 ```bash
-gh issue edit <N> --remove-label "status:tempering" --add-label "status:tempered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:rework" --add-label "status:tempered"
 ```
 
 Proceed to step 7 (PR & Merge).
@@ -148,7 +148,7 @@ Proceed to step 7 (PR & Merge).
 
 Set the label and post a tagged comment:
 ```bash
-gh issue edit <N> --remove-label "status:tempering" --add-label "status:rework"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
 ```
 ```bash
 gh issue comment <N> --body "**[Temperer]** <summary of findings>
@@ -173,7 +173,7 @@ gh issue comment <N> --body "**[Temperer]** Escalating to human review.
 <describe the ambiguity or design problem>
 
 *Escalated by the Forge Temperer.*"
-gh issue edit <N> --remove-label "status:tempering" --add-label "agent:needs-human"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
 ```
 
 Post the ledger (step 8) and stop. Do not proceed to PR & Merge.
@@ -211,7 +211,7 @@ pr_number=$(echo "$pr_url" | grep -oE '[0-9]+$')
 **Merge** (use the captured PR number):
 ```bash
 gh pr merge "$pr_number" --squash --delete-branch
-gh issue edit <N> --remove-label "status:tempered"
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework"
 ```
 
 **Cleanup locally:**
@@ -257,6 +257,7 @@ gh issue comment <N> --body "**[Temperer Ledger]**
 
 ## Rules
 
+- **Defensive label transitions.** Every `gh issue edit` that changes a status label must remove ALL other status labels (`status:ready`, `status:hammering`, `status:hammered`, `status:tempering`, `status:tempered`, `status:rework`) before adding the new one. Never remove and add the same label in one command. This prevents stale labels from accumulating if a previous transition was interrupted.
 - **Read-only review.** Never modify the code.
 - **Always confer with the user** on the verdict.
 - **Tag your comments.** Always prefix with `**[Temperer]**`.


### PR DESCRIPTION
## Summary
- Replace all 19 targeted `--remove-label` commands across 4 agent files with defensive patterns that remove ALL other status labels before adding the new one
- Each command excludes the label being added from the removal list (since `gh issue edit` removes win over adds in the same command)
- Add a "Defensive label transitions" rule to each agent's Rules section for ad-hoc transitions outside code blocks
- Collapse the dual-alternative "Set Status" commands in both Blacksmith files into a single defensive command (removing the `2>/dev/null` error suppression)

Closes #250

## Test plan
- [x] All 42 bats tests pass
- [x] Verified `gh issue edit --remove-label` silently succeeds for labels not on the issue (but existing in the repo)
- [x] Verified no command removes and adds the same label
- [x] code-reviewer, silent-failure-hunter, pr-test-analyzer all ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)