### PR TITLE
feat: pin model selection per project

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -136,6 +136,40 @@ for name, proj in cfg.get('projects', {}).items():
     fi
 }
 
+# get_project_model — read the model setting for the current project.
+get_project_model() {
+    local project_name
+    project_name=$(_forge_project_name)
+    python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    model = cfg['projects'][sys.argv[2]].get('model', '')
+    if model:
+        print(model)
+except (KeyError, TypeError, FileNotFoundError):
+    pass
+" "$FORGE_CONFIG_DIR/config.json" "$project_name" 2>/dev/null || true
+}
+
+# set_project_model — set the model for the current project.
+# Usage: set_project_model <model>
+set_project_model() {
+    local project_name
+    project_name=$(_forge_project_name)
+    python3 -c "
+import json, sys
+cfg_path, proj, model = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(cfg_path) as f:
+    cfg = json.load(f)
+cfg['projects'][proj]['model'] = model
+with open(cfg_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+" "$FORGE_CONFIG_DIR/config.json" "$project_name" "$1"
+}
+
 # --- Session management ---
 # Each agent maintains a session history per project.
 # Sessions are scoped to individual issues (or invocations for non-issue agents).
@@ -541,6 +575,10 @@ run_forge_agent() {
 }' "$agent_file" | tr '\n' ',' | sed 's/,$//')
     fi
 
+    # Read project model setting
+    local project_model
+    project_model=$(get_project_model)
+
     local cmd=()
     if [ -n "$resume_session" ]; then
         # Resume an existing session by UUID
@@ -555,6 +593,7 @@ run_forge_agent() {
         [ -n "$prompt" ] && cmd+=(-p "$prompt")
         [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     fi
+    [ -n "$project_model" ] && cmd+=(--model "$project_model")
 
     # Start spinner for headless agents (those with -p flag)
     if [ -n "$prompt" ]; then

--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -77,6 +77,7 @@ show_usage() {
     echo "  init --resume    Resume a failed or interrupted bootstrap"
     echo "  version          Show installed version and check for updates"
     echo "  update           Update Forge to the latest version"
+    echo "  config           View or set project configuration"
     echo "  doctor           Check tool versions and project health"
     echo "  uninstall        Remove Forge from your system"
     echo ""
@@ -104,6 +105,18 @@ show_command_help() {
             echo ""
             echo "Options:"
             echo "  --resume    Resume from where a previous bootstrap stopped"
+            ;;
+        config)
+            echo "forge config — View or set project configuration"
+            echo ""
+            echo "Usage: forge config [key] [value]"
+            echo ""
+            echo "  forge config             Show all configuration"
+            echo "  forge config model       Show current model"
+            echo "  forge config model opus  Set model to opus"
+            echo ""
+            echo "Available keys:"
+            echo "  model    Claude model alias (opus, sonnet, haiku) or full name"
             ;;
         version)
             echo "forge version — Show installed version"
@@ -330,6 +343,55 @@ case "${1:-}" in
             done
         fi
         ;;
+    config)
+        shift
+        require_forge_project
+
+        local config_key="${1:-}"
+        local config_value="${2:-}"
+
+        if [ -z "$config_key" ]; then
+            echo ""
+            echo "Project Configuration"
+            echo "====================="
+            echo ""
+            local current_model
+            current_model=$(get_project_model)
+            echo "  model: ${current_model:-(not set)}"
+            echo ""
+            echo "Usage: forge config model [opus|sonnet|haiku]"
+            echo ""
+            exit 0
+        fi
+
+        case "$config_key" in
+            model)
+                if [ -z "$config_value" ]; then
+                    local current_model
+                    current_model=$(get_project_model)
+                    echo "${current_model:-(not set)}"
+                else
+                    case "$config_value" in
+                        opus|sonnet|haiku) ;;
+                        claude-*) ;;
+                        *)
+                            forge_fail "Unknown model '$config_value'. Use opus, sonnet, or haiku."
+                            exit 1
+                            ;;
+                    esac
+                    set_project_model "$config_value"
+                    forge_ok "Model set to $config_value"
+                fi
+                ;;
+            *)
+                forge_fail "Unknown config key: $config_key"
+                echo ""
+                echo "Available keys: model"
+                exit 1
+                ;;
+        esac
+        ;;
+
     doctor)
         require_forge_project
 
@@ -437,6 +499,18 @@ case "${1:-}" in
             fi
         else
             echo -e "  ${DIM}-${NC} Skipped (GitHub not authenticated)"
+        fi
+
+        echo ""
+        echo "Project:"
+
+        local doctor_model
+        doctor_model=$(get_project_model)
+        if [ -n "$doctor_model" ]; then
+            echo -e "  ${GREEN}✓${NC} Model: $doctor_model"
+        else
+            echo -e "  ${YELLOW}⚠${NC} Model: (not set — using default)"
+            echo "    Pin a model with: forge config model <opus|sonnet|haiku>"
         fi
 
         echo ""

--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -514,6 +514,30 @@ EOF
     ok "$label"
 }
 
+# Select Claude model for this project
+select_model() {
+    local label="Claude model"
+    local existing_model
+    existing_model=$(get_project_model)
+    if [ -n "$existing_model" ]; then
+        skip "$label ($existing_model)"
+        return
+    fi
+    printf "  Claude model (opus/sonnet/haiku) [sonnet]: "
+    read -r model_choice
+    model_choice="${model_choice:-sonnet}"
+    case "$model_choice" in
+        opus|sonnet|haiku) ;;
+        claude-*) ;;
+        *)
+            add_warning "Unknown model '$model_choice' — defaulting to sonnet."
+            model_choice="sonnet"
+            ;;
+    esac
+    set_project_model "$model_choice"
+    ok "$label ($model_choice)"
+}
+
 # ============================================================
 # Run all steps
 # ============================================================
@@ -534,6 +558,7 @@ configure_vercel_environments
 create_labels
 cleanup_default_labels
 write_forge_config || add_warning "Forge config write failed. Not critical."
+select_model || add_warning "Model selection failed. Set later with: forge config model <name>"
 
 # ============================================================
 # Done

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -561,6 +561,110 @@ EOF
     [[ "$output" != *"--agent"* ]]
 }
 
+# --- project model ---
+
+@test "get_project_model returns empty when no model set" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    run get_project_model
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "set_project_model writes and get_project_model reads back" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    set_project_model "opus"
+    run get_project_model
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == "opus" ]]
+}
+
+@test "run_forge_agent passes --model when project model is set" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "model": "opus",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "" ""
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--model"* ]]
+    [[ "$output" == *"opus"* ]]
+}
+
+@test "run_forge_agent omits --model when no project model set" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "" ""
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"--model"* ]]
+}
+
+@test "run_forge_agent passes --model on resume path" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "model": "sonnet",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "Continue." "" --resume-session "bbbbbbbb-2222-3333-4444-555555555555"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--resume"* ]]
+    [[ "$output" == *"--model"* ]]
+    [[ "$output" == *"sonnet"* ]]
+}
+
 # --- run_stoke_loop ---
 
 # Helper: mock gh that returns an issue on first status query, empty on second.


### PR DESCRIPTION
## Summary
- Record Claude model in project config at `forge init` time (interactive prompt, default sonnet)
- `run_forge_agent` reads model from config and passes `--model` to every `claude` invocation (fresh and resume paths)
- `forge config model [value]` command to view/change model
- `forge doctor` shows current model setting
- `select_model` is idempotent on `--resume`, uses library functions (no inline Python duplication)

Closes #263

## Test plan
- [x] All 51 bats tests pass (46 existing + 5 new)
- [x] ShellCheck clean
- [x] New tests: model get/set roundtrip, --model passthrough on fresh and resume paths, omitted when unset
- [x] code-reviewer, silent-failure-hunter, pr-test-analyzer all ran — findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)