### PR TITLE
fix: interactive agents stay interactive, not headless

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -651,12 +651,13 @@ check_auth() {
 # --- Agent invocation ---
 
 # run_forge_agent — invoke a Claude Code session with a named agent.
-# Usage: run_forge_agent <agent-name> [prompt] [spinner-message] [--session-name <name>] [--session-id <uuid>] [--resume-session <uuid>]
+# Usage: run_forge_agent <agent-name> [prompt] [spinner-message] [--session-name <name>] [--session-id <uuid>] [--resume-session <uuid>] [--interactive]
 # Extracts tools from agent frontmatter and passes --allowedTools for auto-approval.
 # Options (after positional args):
 #   --session-name <name>   Start a new named session (adds -n <name> to claude)
 #   --session-id <uuid>     Pre-assign a UUID for the session (adds --session-id <uuid> to claude)
 #   --resume-session <uuid>  Resume an existing session by UUID (adds --resume <uuid> to claude)
+#   --interactive            Stay interactive — prompt becomes a positional arg instead of -p
 run_forge_agent() {
     local agent_name="$1"
     local prompt="${2:-}"
@@ -664,12 +665,13 @@ run_forge_agent() {
     shift; shift 2>/dev/null || true; shift 2>/dev/null || true
 
     # Parse optional flags
-    local session_name="" session_id="" resume_session=""
+    local session_name="" session_id="" resume_session="" interactive=""
     while [ $# -gt 0 ]; do
         case "$1" in
             --session-name)   session_name="$2"; shift 2 ;;
             --session-id)     session_id="$2"; shift 2 ;;
             --resume-session) resume_session="$2"; shift 2 ;;
+            --interactive)    interactive=1; shift ;;
             *) shift ;;
         esac
     done
@@ -694,21 +696,24 @@ run_forge_agent() {
     if [ -n "$resume_session" ]; then
         # Resume an existing session by UUID
         cmd=(claude --resume "$resume_session")
-        [ -n "$prompt" ] && cmd+=(-p "$prompt")
         [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     else
         # Start a new session
         cmd=(claude --agent "forge:${agent_name_lower}")
         [ -n "$session_id" ] && cmd+=(--session-id "$session_id")
         [ -n "$session_name" ] && cmd+=(-n "$session_name")
-        [ -n "$prompt" ] && cmd+=(-p "$prompt")
         [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     fi
     [ -n "$project_model" ] && cmd+=(--model "$project_model")
 
-    # Start spinner for headless agents (those with -p flag)
+    # Append prompt: -p for headless (print and exit), positional arg for interactive
     if [ -n "$prompt" ]; then
-        _forge_spinner_start "$spinner_msg"
+        if [ -n "$interactive" ]; then
+            cmd+=("$prompt")
+        else
+            cmd+=(-p "$prompt")
+            _forge_spinner_start "$spinner_msg"
+        fi
     fi
 
     local exit_code=0

--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -585,7 +585,7 @@ case "${1:-}" in
                 local smelter_agent
                 smelter_agent=$(_resolve_smelter_agent "interactive")
                 agent_msg SMELTER "Resuming..."
-                if ! run_forge_agent "$smelter_agent" "Continue where you left off." "" --resume-session "$resumed_session"; then
+                if ! run_forge_agent "$smelter_agent" "Continue where you left off." "" --resume-session "$resumed_session" --interactive; then
                     agent_fail SMELTER "failed."
                     exit 1
                 fi
@@ -610,7 +610,7 @@ case "${1:-}" in
                 session_id=$(_forge_uuid)
                 set_session "smelter" "$session_name" "$session_id" "" 2>/dev/null || true
                 agent_msg SMELTER "Starting..."
-                if ! run_forge_agent "$smelter_agent" "Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name"; then
+                if ! run_forge_agent "$smelter_agent" "Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name" --interactive; then
                     agent_fail SMELTER "failed."
                     exit 1
                 fi
@@ -659,7 +659,7 @@ case "${1:-}" in
             resumed_session=$(pick_session "blacksmith")
             agent_msg BLACKSMITH "Starting on issue #$issue..."
             if [ -n "$resumed_session" ]; then
-                if ! run_forge_agent "Blacksmith" "Continue where you left off. Work on issue #${issue}." "" --resume-session "$resumed_session"; then
+                if ! run_forge_agent "Blacksmith" "Continue where you left off. Work on issue #${issue}." "" --resume-session "$resumed_session" --interactive; then
                     agent_fail BLACKSMITH "failed on issue #$issue."
                     exit 1
                 fi
@@ -667,7 +667,7 @@ case "${1:-}" in
                 local session_id session_name="blacksmith-issue-${issue}"
                 session_id=$(_forge_uuid)
                 set_session "blacksmith" "$session_name" "$session_id" "$issue" 2>/dev/null || true
-                if ! run_forge_agent "Blacksmith" "Read INGOT.md in the project root for architectural context before starting. Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name"; then
+                if ! run_forge_agent "Blacksmith" "Read INGOT.md in the project root for architectural context before starting. Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name" --interactive; then
                     agent_fail BLACKSMITH "failed on issue #$issue."
                     exit 1
                 fi
@@ -716,7 +716,7 @@ case "${1:-}" in
             resumed_session=$(pick_session "temperer")
             agent_msg TEMPERER "Starting on issue #$issue..."
             if [ -n "$resumed_session" ]; then
-                if ! run_forge_agent "Temperer" "Continue where you left off. Review issue #${issue}." "" --resume-session "$resumed_session"; then
+                if ! run_forge_agent "Temperer" "Continue where you left off. Review issue #${issue}." "" --resume-session "$resumed_session" --interactive; then
                     agent_fail TEMPERER "failed on issue #$issue."
                     exit 1
                 fi
@@ -724,7 +724,7 @@ case "${1:-}" in
                 local session_id session_name="temperer-issue-${issue}"
                 session_id=$(_forge_uuid)
                 set_session "temperer" "$session_name" "$session_id" "$issue" 2>/dev/null || true
-                if ! run_forge_agent "Temperer" "Read INGOT.md in the project root for architectural context before starting. Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name"; then
+                if ! run_forge_agent "Temperer" "Read INGOT.md in the project root for architectural context before starting. Greet the user and begin." "" --session-id "$session_id" --session-name "$session_name" --interactive; then
                     agent_fail TEMPERER "failed on issue #$issue."
                     exit 1
                 fi
@@ -789,7 +789,7 @@ case "${1:-}" in
                 local honer_agent
                 honer_agent=$(_resolve_honer_agent "interactive")
                 agent_msg HONER "Resuming..."
-                if ! run_forge_agent "$honer_agent" "Continue where you left off." "" --resume-session "$resumed_session"; then
+                if ! run_forge_agent "$honer_agent" "Continue where you left off." "" --resume-session "$resumed_session" --interactive; then
                     agent_fail HONER "failed."
                     exit 1
                 fi
@@ -815,7 +815,7 @@ case "${1:-}" in
                     set_session "honer" "$session_name" "$session_id" "" 2>/dev/null || true
                 fi
                 agent_msg HONER "Starting..."
-                if ! run_forge_agent "$honer_agent" "$honer_prompt" "" --session-id "$session_id" --session-name "$session_name"; then
+                if ! run_forge_agent "$honer_agent" "$honer_prompt" "" --session-id "$session_id" --session-name "$session_name" --interactive; then
                     agent_fail HONER "failed."
                     exit 1
                 fi

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -244,6 +244,44 @@ EOF
     [[ "$status" -eq 42 ]]
 }
 
+@test "run_forge_agent --interactive passes prompt as positional arg, not -p" {
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "Greet the user." "" --interactive
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"Greet the user."* ]]
+    [[ "$output" != *"-p"* ]]
+}
+
+@test "run_forge_agent --interactive with --resume-session omits -p" {
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "Continue." "" --resume-session "cccccccc-1111-2222-3333-444444444444" --interactive
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--resume"* ]]
+    [[ "$output" == *"Continue."* ]]
+    [[ "$output" != *"-p"* ]]
+}
+
+@test "run_forge_agent --interactive with empty prompt passes no prompt" {
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "" "" --interactive
+    [[ "$status" -eq 0 ]]
+    [[ "$output" != *"-p"* ]]
+}
+
+@test "run_forge_agent --interactive with --session-id omits -p" {
+    _create_agent_file "smelter"
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Smelter" "Greet the user." "" --session-id "dddddddd-1111-2222-3333-444444444444" --session-name "smelter-ingot" --interactive
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"--agent"* ]]
+    [[ "$output" == *"--session-id"* ]]
+    [[ "$output" == *"Greet the user."* ]]
+    [[ "$output" != *"-p"* ]]
+}
+
 # --- find_issue_for_hammer ---
 
 @test "find_issue_for_hammer returns needs-human issue first" {
@@ -543,6 +581,7 @@ EOF
     [[ "$output" == *"--resume"* ]]
     [[ "$output" == *"bbbbbbbb-2222-3333-4444-555555555555"* ]]
     [[ "$output" != *"--agent"* ]]
+    [[ "$output" == *"-p"* ]]
 }
 
 # --- project state detection ---


### PR DESCRIPTION
## Summary

- `run_forge_agent` unconditionally added `-p` (print/headless mode) when a prompt was provided, causing all interactive sessions (`forge smelt`, `hammer`, `temper`, `hone`) to exit immediately after the agent's first response
- Added `--interactive` flag to `run_forge_agent`: passes prompt as a positional argument (interactive) instead of `-p` (headless), skips spinner
- Updated all 8 interactive callers; headless/auto callers unchanged
- Added 4 new tests, strengthened 1 existing test

Closes #278

## Test plan
- [x] All 64 tests pass (`bats tests/cli/forge_lib.bats`)
- [ ] Manual: `forge smelt` in an initialized project stays interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)