### PR TITLE
fix: install feature-dev and frontend-design plugins

### DIFF
--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -308,7 +308,7 @@ case "${1:-}" in
 
             # Refresh plugin caches and reinstall
             echo -e "${BLUE}Refreshing plugins...${NC}"
-            for plugin in forge vercel; do
+            for plugin in forge vercel feature-dev frontend-design; do
                 for cache_dir in "$HOME/.claude/plugins/cache"/*/"$plugin"/*/; do
                     [ -d "$cache_dir" ] && rm -rf "$cache_dir"
                 done
@@ -317,6 +317,8 @@ case "${1:-}" in
                 "Forge|forge@forge"
                 "Vercel|vercel@claude-plugins-official"
                 "PR Review Toolkit|pr-review-toolkit@claude-plugins-official"
+                "Feature Dev|feature-dev@claude-plugins-official"
+                "Frontend Design|frontend-design@claude-plugins-official"
             )
             for plugin_entry in "${plugins[@]}"; do
                 display_name="${plugin_entry%%|*}"

--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,14 @@ if command -v claude &>/dev/null; then
         && echo -e "  ${GREEN}[x]${NC} PR Review Toolkit plugin installed" \
         || echo -e "  ${YELLOW}[!]${NC} PR Review Toolkit plugin failed. Run manually: claude plugin install pr-review-toolkit@claude-plugins-official"
 
+    claude plugin install feature-dev@claude-plugins-official 2>/dev/null \
+        && echo -e "  ${GREEN}[x]${NC} Feature Dev plugin installed" \
+        || echo -e "  ${YELLOW}[!]${NC} Feature Dev plugin failed. Run manually: claude plugin install feature-dev@claude-plugins-official"
+
+    claude plugin install frontend-design@claude-plugins-official 2>/dev/null \
+        && echo -e "  ${GREEN}[x]${NC} Frontend Design plugin installed" \
+        || echo -e "  ${YELLOW}[!]${NC} Frontend Design plugin failed. Run manually: claude plugin install frontend-design@claude-plugins-official"
+
     # Install agent-browser CLI for browser automation
     if ! command -v agent-browser &>/dev/null; then
         npm install -g agent-browser 2>/dev/null \

--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -45,6 +45,7 @@ The target stack is **Next.js + Tailwind CSS + TypeScript**, deployed on **Verce
   - **ai-architect** — AI SDK patterns, model selection, agent architecture, RAG pipelines
   - **deployment-expert** — Build failures, function runtime, env vars, DNS, CI/CD, rollbacks
   - **performance-optimizer** — Core Web Vitals, caching, image/font optimization, bundle size
+- The **frontend-design** skill is available for creating distinctive, production-grade UI. Use it when implementing visual components, pages, and layouts — it generates creative, polished code that avoids generic AI aesthetics.
 
 ## Git Workflow
 

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -45,6 +45,7 @@ The target stack is **Next.js + Tailwind CSS + TypeScript**, deployed on **Verce
   - **ai-architect** — AI SDK patterns, model selection, agent architecture, RAG pipelines
   - **deployment-expert** — Build failures, function runtime, env vars, DNS, CI/CD, rollbacks
   - **performance-optimizer** — Core Web Vitals, caching, image/font optimization, bundle size
+- The **frontend-design** skill is available for creating distinctive, production-grade UI. Use it when implementing visual components, pages, and layouts — it generates creative, polished code that avoids generic AI aesthetics.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

- Add `feature-dev` and `frontend-design` plugins to `install.sh` and `forge update` managed dependencies
- Add both to the cache-clearing loop in `forge update`
- Surface `frontend-design` skill in Blacksmith and Auto-Blacksmith agent instructions

Closes #280

## Test plan
- [x] All 64 tests pass
- [ ] Manual: `forge update` installs/refreshes all 5 plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)