### PR TITLE
fix: preserve agent name casing for --agent flag, prompt before flags

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -693,28 +693,33 @@ run_forge_agent() {
     local project_model
     project_model=$(get_project_model)
 
-    local cmd=()
+    # Build command — interactive prompt must be the first positional arg
+    # (before any flags). --agent must preserve original casing because the
+    # plugin system registers agents by frontmatter name (e.g. forge:Smelter).
+    local cmd=(claude)
+
+    # Interactive prompt goes immediately after 'claude' (positional arg)
+    if [ -n "$interactive" ] && [ -n "$prompt" ]; then
+        cmd+=("$prompt")
+    fi
+
+    # Mode: resume existing session vs start new one
     if [ -n "$resume_session" ]; then
-        # Resume an existing session by UUID
-        cmd=(claude --resume "$resume_session")
-        [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
+        cmd+=(--resume "$resume_session")
     else
-        # Start a new session
-        cmd=(claude --agent "forge:${agent_name_lower}")
+        cmd+=(--agent "forge:${agent_name}")
         [ -n "$session_id" ] && cmd+=(--session-id "$session_id")
         [ -n "$session_name" ] && cmd+=(-n "$session_name")
-        [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     fi
+
+    # Shared flags
+    [ -n "$tools" ] && cmd+=(--allowedTools "$tools")
     [ -n "$project_model" ] && cmd+=(--model "$project_model")
 
-    # Append prompt: -p for headless (print and exit), positional arg for interactive
-    if [ -n "$prompt" ]; then
-        if [ -n "$interactive" ]; then
-            cmd+=("$prompt")
-        else
-            cmd+=(-p "$prompt")
-            _forge_spinner_start "$spinner_msg"
-        fi
+    # Headless prompt uses -p flag (flag order doesn't matter)
+    if [ -n "$prompt" ] && [ -z "$interactive" ]; then
+        cmd+=(-p "$prompt")
+        _forge_spinner_start "$spinner_msg"
     fi
 
     local exit_code=0

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -207,7 +207,22 @@ EOF
     run run_forge_agent "Smelter"
     [[ "$status" -eq 0 ]]
     [[ "$output" == *"--agent"* ]]
-    [[ "$output" == *"forge:smelter"* ]]
+    [[ "$output" == *"forge:Smelter"* ]]
+}
+
+@test "run_forge_agent preserves agent name casing in --agent flag" {
+    mkdir -p "$FORGE_REPO/plugin/agents"
+    cat > "$FORGE_REPO/plugin/agents/honer-audit.md" <<'EOF'
+---
+name: Honer-Audit
+tools:
+  - Bash
+---
+EOF
+    mock_claude_with 'echo "called: $*"'
+    run run_forge_agent "Honer-Audit"
+    [[ "$status" -eq 0 ]]
+    [[ "$output" == *"forge:Honer-Audit"* ]]
 }
 
 @test "run_forge_agent passes prompt with -p flag" {
@@ -251,6 +266,8 @@ EOF
     [[ "$status" -eq 0 ]]
     [[ "$output" == *"Greet the user."* ]]
     [[ "$output" != *"-p"* ]]
+    # Prompt must appear before --agent flag
+    [[ "$output" == *"called: Greet the user. --agent"* ]]
 }
 
 @test "run_forge_agent --interactive with --resume-session omits -p" {
@@ -261,6 +278,8 @@ EOF
     [[ "$output" == *"--resume"* ]]
     [[ "$output" == *"Continue."* ]]
     [[ "$output" != *"-p"* ]]
+    # Prompt must appear before --resume flag
+    [[ "$output" == *"called: Continue. --resume"* ]]
 }
 
 @test "run_forge_agent --interactive with empty prompt passes no prompt" {
@@ -280,6 +299,8 @@ EOF
     [[ "$output" == *"--session-id"* ]]
     [[ "$output" == *"Greet the user."* ]]
     [[ "$output" != *"-p"* ]]
+    # Prompt must appear before --agent flag
+    [[ "$output" == *"called: Greet the user. --agent"* ]]
 }
 
 # --- find_issue_for_hammer ---


### PR DESCRIPTION
## Summary

- `run_forge_agent` lowercased agent names for the `--agent` flag (`forge:smelter`), but the plugin system registers them with original casing (`forge:Smelter`). Interactive agents silently loaded as plain Claude without the agent definition.
- Interactive prompts were appended after flags, but Claude CLI requires positional args before flags.
- Fixed: use original `agent_name` for `--agent`, keep `agent_name_lower` for file path only. Prompt placed as first arg after `claude`.
- Added 1 new casing test, updated 4 existing tests with casing/ordering assertions.

Closes #286

## Test plan
- [x] All 65 tests pass
- [x] Manually verified: `forge smelt` loads Smelter agent definition correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)