### PR TITLE
fix: Smelter monorepo Vercel setup — defer per-app linking, use MCP for config

### DIFF
--- a/plugin/agents/auto-smelter.md
+++ b/plugin/agents/auto-smelter.md
@@ -115,27 +115,26 @@ git push origin main
 
 ### 5. Vercel Setup
 
-Link the project to Vercel and configure environments. All steps are non-blocking — if any fail, warn and continue.
+All steps are non-blocking — if any fail, warn and continue.
 
-**Link the project:**
+**Single-app projects:** Link the project, configure production branch, and create Staging environment.
+
 ```bash
 vercel link --yes
 ```
 
-**Set production branch to `production`:**
-Use the Vercel MCP tools or `vercel` CLI to set the production branch. If neither provides a direct method, use WebSearch to find the current correct Vercel API endpoint for updating a project's production branch — do not hardcode an API version, as these endpoints change.
+Set production branch to `production`: Use the Vercel MCP tools or `vercel` CLI. If neither provides a direct method, use WebSearch to find the current correct Vercel API endpoint — do not hardcode an API version, as these endpoints change.
 
-**Create Staging environment:**
+Create Staging environment:
 ```bash
 project_id=$(python3 -c "import json; print(json.load(open('.vercel/project.json')).get('projectId',''))")
 vercel api "/v9/projects/$project_id/custom-environments" -X POST \
   --input <(echo '{"slug":"Staging","description":"Staging environment tracking main","branchMatcher":{"type":"equals","pattern":"main"}}')
 ```
 
-**For monorepos:** Do **not** link individual apps at scaffold time — the real apps don't exist yet (`create-turbo` only produces placeholder `web`/`docs` apps). Instead:
-1. The root `vercel link` above creates the initial Vercel project for the monorepo.
-2. Per-app Vercel project setup will happen when each app is implemented — see the issue creation guidance in step 9.
-3. Include the full per-app Vercel setup procedure in INGOT.md's Deployment & Environments section (see step 6).
+**Monorepos:** Do **not** create or link any Vercel projects at scaffold time — the real apps don't exist yet (`create-turbo` only produces placeholder apps). Each app gets its own Vercel project when it is implemented. Instead:
+1. Include the full per-app Vercel project setup procedure in INGOT.md's Deployment & Environments section (see step 6).
+2. Add Vercel setup acceptance criteria to each deployable app issue (see step 9).
 
 If Vercel setup fails, document what was attempted and what needs manual follow-up in INGOT.md.
 
@@ -145,7 +144,7 @@ Write `INGOT.md` to the project root using the Write tool. This is the architect
 
 - **Key Decisions** table — architectural decisions with rationale (include a Date column for future entries)
 - **Approaches Rejected** table — alternatives considered and why they were rejected (include a Date column)
-- **Deployment & Environments** section — Vercel project(s), branch-environment mapping, env vars per environment, database branching strategy if applicable. **For monorepos:** include a step-by-step "Vercel Project Setup" procedure for each deployable app (link, set root directory, configure production branch, create Staging environment, connect shared resources) so the Blacksmith can execute it when implementing each app.
+- **Deployment & Environments** section — Vercel project(s), branch-environment mapping, env vars per environment, database branching strategy if applicable. **For monorepos:** include a step-by-step "Vercel Project Setup" procedure for each deployable app (link, set root directory, enable `sourceFilesOutsideRootDirectory`, configure production branch, create Staging environment, connect shared resources and env vars) so the Blacksmith can execute it when implementing each app.
 - **Design Language** section — color palette, typography, component style direction, spacing conventions. Use the **frontend-design** skill and the Vercel plugin's **shadcn/ui** guidance to create a distinctive visual identity. Do not default to generic templates.
 
 Commit and push to main:
@@ -223,8 +222,9 @@ gh issue create \
 ```
 
 **For monorepos — Vercel setup in deployable app issues:** When creating an issue for a hub/app that will be separately deployed (e.g., each app under `apps/`), include Vercel project setup in the acceptance criteria:
-- `Vercel project created and linked for this app (vercel link from app directory, root directory configured)`
+- `Vercel project created and linked (vercel link from app directory, root directory set, sourceFilesOutsideRootDirectory enabled)`
 - `Production branch set to production, Staging environment created tracking main`
+- `Shared resources connected (Neon, Blob, env vars) per the procedure in INGOT.md`
 
 This ensures per-app Vercel configuration happens when the app code actually exists, not at scaffold time.
 

--- a/plugin/agents/smelter.md
+++ b/plugin/agents/smelter.md
@@ -123,27 +123,26 @@ git push origin main
 
 ### 6. Vercel Setup
 
-Link the project to Vercel and configure environments. All steps are non-blocking — if any fail, warn and continue.
+All steps are non-blocking — if any fail, warn and continue.
 
-**Link the project:**
+**Single-app projects:** Link the project, configure production branch, and create Staging environment.
+
 ```bash
 vercel link --yes
 ```
 
-**Set production branch to `production`:**
-Use the Vercel MCP tools or `vercel` CLI to set the production branch. If neither provides a direct method, use WebSearch to find the current correct Vercel API endpoint for updating a project's production branch — do not hardcode an API version, as these endpoints change.
+Set production branch to `production`: Use the Vercel MCP tools or `vercel` CLI. If neither provides a direct method, use WebSearch to find the current correct Vercel API endpoint — do not hardcode an API version, as these endpoints change.
 
-**Create Staging environment:**
+Create Staging environment:
 ```bash
 project_id=$(python3 -c "import json; print(json.load(open('.vercel/project.json')).get('projectId',''))")
 vercel api "/v9/projects/$project_id/custom-environments" -X POST \
   --input <(echo '{"slug":"Staging","description":"Staging environment tracking main","branchMatcher":{"type":"equals","pattern":"main"}}')
 ```
 
-**For monorepos:** Do **not** link individual apps at scaffold time — the real apps don't exist yet (`create-turbo` only produces placeholder `web`/`docs` apps). Instead:
-1. The root `vercel link` above creates the initial Vercel project for the monorepo.
-2. Per-app Vercel project setup will happen when each app is implemented — see the issue creation guidance in step 11.
-3. Include the full per-app Vercel setup procedure in INGOT.md's Deployment & Environments section (see step 7).
+**Monorepos:** Do **not** create or link any Vercel projects at scaffold time — the real apps don't exist yet (`create-turbo` only produces placeholder apps). Each app gets its own Vercel project when it is implemented. Instead:
+1. Include the full per-app Vercel project setup procedure in INGOT.md's Deployment & Environments section (see step 7).
+2. Add Vercel setup acceptance criteria to each deployable app issue (see step 11).
 
 If Vercel setup fails, document what was attempted and what needs manual follow-up in INGOT.md.
 
@@ -153,7 +152,7 @@ Write `INGOT.md` to the project root using the Write tool. This is the architect
 
 - **Key Decisions** table — architectural decisions with rationale (include a Date column for future entries)
 - **Approaches Rejected** table — alternatives considered and why they were rejected (include a Date column)
-- **Deployment & Environments** section — Vercel project(s), branch-environment mapping, env vars per environment, database branching strategy if applicable. **For monorepos:** include a step-by-step "Vercel Project Setup" procedure for each deployable app (link, set root directory, configure production branch, create Staging environment, connect shared resources) so the Blacksmith can execute it when implementing each app.
+- **Deployment & Environments** section — Vercel project(s), branch-environment mapping, env vars per environment, database branching strategy if applicable. **For monorepos:** include a step-by-step "Vercel Project Setup" procedure for each deployable app (link, set root directory, enable `sourceFilesOutsideRootDirectory`, configure production branch, create Staging environment, connect shared resources and env vars) so the Blacksmith can execute it when implementing each app.
 - **Design Language** section — color palette, typography, component style direction, spacing conventions. Use the **frontend-design** skill and the Vercel plugin's **shadcn/ui** guidance to create a distinctive visual identity. Do not default to generic templates.
 
 Commit and push to main:
@@ -238,8 +237,9 @@ gh issue create \
 ```
 
 **For monorepos — Vercel setup in deployable app issues:** When creating an issue for a hub/app that will be separately deployed (e.g., each app under `apps/`), include Vercel project setup in the acceptance criteria:
-- `Vercel project created and linked for this app (vercel link from app directory, root directory configured)`
+- `Vercel project created and linked (vercel link from app directory, root directory set, sourceFilesOutsideRootDirectory enabled)`
 - `Production branch set to production, Staging environment created tracking main`
+- `Shared resources connected (Neon, Blob, env vars) per the procedure in INGOT.md`
 
 This ensures per-app Vercel configuration happens when the app code actually exists, not at scaffold time.
 


### PR DESCRIPTION
## Summary

- Monorepo per-app Vercel linking at scaffold time fails because real apps don't exist yet — replaced with deferred approach: document procedure in INGOT.md, embed Vercel setup acceptance criteria in each hub issue
- Removed hardcoded broken `PATCH /v9/projects/{id}` production branch endpoint — agents now use Vercel MCP tools or web search for current correct method
- Both smelter.md and auto-smelter.md updated (Vercel Setup step, INGOT.md step, issue creation step)

Closes #292

## Test plan
- [x] All 66 tests pass
- [ ] Manual: next `forge smelt` on a monorepo project defers per-app linking and includes Vercel setup in hub issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)