### PR TITLE
fix: post ledger before label transition for crash-safe ordering

### DIFF
--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -205,14 +205,13 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '.[] | select(.body | test(
 gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <original body>"
 ```
 
-### 11. Push & Update Status
+### 11. Push & Post Ledger Comment
 
 ```bash
 git push -u origin HEAD
-gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
 ```
 
-### 12. Post Ledger Comment
+Post the ledger comment **before** updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 
 **First pass:**
 ```bash
@@ -261,6 +260,12 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 *Posted by the Forge Blacksmith.*"
 ```
 
+### 12. Update Status
+
+```bash
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
+```
+
 ## Rules
 
 - **Never substitute a different issue** than the one you were assigned in the prompt.
@@ -273,6 +278,6 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 - **Always challenge your plan.** Draft first, then launch `feature-dev:code-architect` (or Plan for greenfield) as devil's advocate. Never skip the challenge step.
 - **Never stub features.** Implement fully or escalate. No placeholder code, no TODO comments, no "coming soon" messages.
 - **Fix everything you encounter.** Linting errors, bugs, test failures, type errors — fix them. Do not file issues for things you can fix during implementation.
-- **Action before ledger.** Push and update the status label before posting the ledger comment.
+- **Ledger before label transition.** Post the ledger comment before updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 - **Max rework cycles:** If sent back 7 times total, escalate to `agent:needs-human`.
 - **File out-of-scope features only.** When you encounter genuinely large out-of-scope capabilities during implementation: file them as feature requests with `type:feature` + appropriate `scope:*` label only — no `ai-generated`, no `status:ready` (Smelter picks up). Fix bugs and small issues you encounter directly.

--- a/plugin/agents/auto-temperer.md
+++ b/plugin/agents/auto-temperer.md
@@ -130,6 +130,8 @@ This is a lean evaluation. Read the artifacts directly — no subagent launches 
 
 ### 5a. On APPROVE
 
+Post the ledger (step 7) **before** transitioning the label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
+
 ```bash
 gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:rework" --add-label "status:tempered"
 ```
@@ -138,10 +140,7 @@ Proceed to step 6 (PR & Merge).
 
 ### 5b. On REWORK
 
-Set the label and post a tagged comment:
-```bash
-gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
-```
+Post a tagged comment with the rework feedback:
 ```bash
 gh issue comment <N> --body "**[Temperer]** <summary of findings>
 
@@ -153,7 +152,12 @@ gh issue comment <N> --body "**[Temperer]** <summary of findings>
 *Posted by the Forge Temperer.*"
 ```
 
-Post the ledger (step 7) and stop. Do not proceed to PR & Merge.
+Post the ledger (step 7), then transition the label:
+```bash
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
+```
+
+Stop. Do not proceed to PR & Merge.
 
 ### 5c. On ESCALATE
 
@@ -165,10 +169,14 @@ gh issue comment <N> --body "**[Temperer]** Escalating to human review.
 <describe the ambiguity or design problem>
 
 *Escalated by the Forge Temperer.*"
+```
+
+Post the ledger (step 7), then transition the label:
+```bash
 gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
 ```
 
-Post the ledger (step 7) and stop. Do not proceed to PR & Merge.
+Stop. Do not proceed to PR & Merge.
 
 ### 6. PR & Merge
 
@@ -304,6 +312,6 @@ If any release step fails (PR merge, tag push, release creation), stop and docum
 - **Read-only evaluation.** Never modify the code. Your only write operations are PRs, merges, releases, and GitHub comments.
 - **Never ask questions.** You are running headless. Make judgment calls and document them.
 - **Tag your comments.** Always prefix with `**[Temperer]**`.
-- **Action before ledger.** Post the verdict action (label change + feedback) before the ledger comment.
+- **Ledger before label transition.** Post the ledger comment before updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 - **Never file issues.** If you find problems, include them in the rework feedback for the Blacksmith. The Blacksmith decides whether to fix directly or file a feature request.
 - **Conservative version bumps.** When commit classification is ambiguous, bump lower.

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -224,14 +224,13 @@ gh api repos/{owner}/{repo}/issues/<N>/comments --jq '.[] | select(.body | test(
 gh api repos/{owner}/{repo}/issues/comments/<comment-id> -X PATCH -f body="✅ <original body>"
 ```
 
-### 12. Push & Update Status
+### 12. Push & Post Ledger Comment
 
 ```bash
 git push -u origin HEAD
-gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
 ```
 
-### 13. Post Ledger Comment
+Post the ledger comment **before** updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 
 **First pass:**
 ```bash
@@ -280,6 +279,12 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 *Posted by the Forge Blacksmith.*"
 ```
 
+### 13. Update Status
+
+```bash
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "status:hammered"
+```
+
 ## Rules
 
 - **Defensive label transitions.** Every `gh issue edit` that changes a status label must remove ALL other status labels (`status:ready`, `status:hammering`, `status:hammered`, `status:tempering`, `status:tempered`, `status:rework`) before adding the new one. Never remove and add the same label in one command. This prevents stale labels from accumulating if a previous transition was interrupted.
@@ -291,6 +296,6 @@ gh issue comment <N> --body "**[Blacksmith Ledger]**
 - **Always challenge your plan.** Draft first, then launch `feature-dev:code-architect` (or Plan for greenfield) as devil's advocate. Never skip the challenge step.
 - **Never stub features.** Implement fully or escalate. No placeholder code, no TODO comments, no "coming soon" messages.
 - **Fix everything you encounter.** Linting errors, bugs, test failures, type errors — fix them. Do not file issues for things you can fix during implementation.
-- **Action before ledger.** Push and update the status label before posting the ledger comment.
+- **Ledger before label transition.** Post the ledger comment before updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 - **Max rework cycles:** If sent back 7 times total, escalate to `agent:needs-human`.
 - **File out-of-scope features only.** When you encounter genuinely large out-of-scope capabilities during implementation: present them to the user, then file approved items as feature requests with `type:feature` + appropriate `scope:*` label only — no `ai-generated`, no `status:ready` (Smelter picks up). Fix bugs and small issues you encounter directly.

--- a/plugin/agents/temperer.md
+++ b/plugin/agents/temperer.md
@@ -139,6 +139,8 @@ Iterate based on user feedback. **Get explicit user confirmation on the verdict.
 
 ### 6a. On APPROVE
 
+Post the ledger (step 8) **before** transitioning the label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
+
 ```bash
 gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:rework" --add-label "status:tempered"
 ```
@@ -147,10 +149,7 @@ Proceed to step 7 (PR & Merge).
 
 ### 6b. On REWORK
 
-Set the label and post a tagged comment:
-```bash
-gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
-```
+Post a tagged comment with the rework feedback:
 ```bash
 gh issue comment <N> --body "**[Temperer]** <summary of findings>
 
@@ -162,7 +161,12 @@ gh issue comment <N> --body "**[Temperer]** <summary of findings>
 *Posted by the Forge Temperer.*"
 ```
 
-Post the ledger (step 8) and stop. Do not proceed to PR & Merge.
+Post the ledger (step 8), then transition the label:
+```bash
+gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --add-label "status:rework"
+```
+
+Stop. Do not proceed to PR & Merge.
 
 ### 6c. On ESCALATE
 
@@ -174,10 +178,14 @@ gh issue comment <N> --body "**[Temperer]** Escalating to human review.
 <describe the ambiguity or design problem>
 
 *Escalated by the Forge Temperer.*"
+```
+
+Post the ledger (step 8), then transition the label:
+```bash
 gh issue edit <N> --remove-label "status:ready" --remove-label "status:hammering" --remove-label "status:hammered" --remove-label "status:tempering" --remove-label "status:tempered" --remove-label "status:rework" --add-label "agent:needs-human"
 ```
 
-Post the ledger (step 8) and stop. Do not proceed to PR & Merge.
+Stop. Do not proceed to PR & Merge.
 
 ### 7. PR & Merge
 
@@ -314,6 +322,6 @@ If any release step fails (PR merge, tag push, release creation), stop and repor
 - **Read-only evaluation.** Never modify the code. Your only write operations are PRs, merges, releases, and GitHub comments.
 - **Always confer with the user** on the verdict and on release decisions.
 - **Tag your comments.** Always prefix with `**[Temperer]**`.
-- **Action before ledger.** Post the verdict action (label change + feedback) before the ledger comment.
+- **Ledger before label transition.** Post the ledger comment before updating the status label. This ensures the reasoning is preserved if the agent is interrupted — on resume, the agent can detect the ledger was already posted and just flip the label.
 - **Never file issues.** If you find problems, include them in the rework feedback for the Blacksmith. The Blacksmith decides whether to fix directly or file a feature request.
 - **Conservative version bumps.** When commit classification is ambiguous, bump lower.


### PR DESCRIPTION
## Summary
- Reverses the ordering of ledger posting and label transition in all four pipeline agents (Blacksmith, Auto-Blacksmith, Temperer, Auto-Temperer)
- New order: push code → post ledger → transition label (previously: push → label → ledger)
- Updates the "Action before ledger" rule to "Ledger before label transition" in all four agents

Closes #294

## Test plan
- [x] `bats tests/cli/forge_lib.bats` — all 66 tests pass (agent markdown changes don't affect CLI logic)
- [ ] Manual review: verify each agent's step ordering reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)