### PR TITLE
feat: auto-prune closed-issue sessions, add sessions command

### DIFF
--- a/bin/forge-lib.sh
+++ b/bin/forge-lib.sh
@@ -295,6 +295,7 @@ _forge_project_name() {
 # get_session — read the active session for an agent role.
 # Usage: get_session <agent_role>   (e.g., get_session blacksmith)
 # Prints: <session_id>\t<name>\t<issue>   or empty if no active session.
+# Skips archived sessions so auto/stoke/cast don't resume stale work.
 get_session() {
     local role="$1"
     local project_name
@@ -310,7 +311,7 @@ try:
     active = s.get('active')
     if active:
         entry = next((h for h in s.get('history', []) if h.get('session_id') == active), None)
-        if entry:
+        if entry and not entry.get('archived', False):
             iss = entry.get('issue')
             print(entry['session_id'] + '\t' + entry['name'] + '\t' + (str(iss) if iss is not None else ''))
 except (KeyError, TypeError, FileNotFoundError, json.JSONDecodeError):
@@ -420,17 +421,21 @@ if changed:
 " "$FORGE_CONFIG_DIR/config.json" "$project_name" "$issue_num"
 }
 
-# list_sessions — list all sessions in history for an agent role.
-# Usage: list_sessions <agent_role>
-# Prints: one line per session: <session_id>\t<name>\t<issue>\t<created>\t<active>
-# where <active> is "*" if it's the active session, empty otherwise.
+# list_sessions — list sessions in history for an agent role.
+# Usage: list_sessions <agent_role> [mode]
+# mode: "all" = include archived sessions, default = exclude archived.
+# Prints: one line per session: <session_id>\t<name>\t<issue>\t<created>\t<active>\t<archived>
+# where <active> is "*" if it's the active session, empty otherwise;
+# <archived> is "archived" if the session is archived, empty otherwise.
 list_sessions() {
     local role="$1"
+    local mode="${2:-}"
     local project_name
     project_name=$(_forge_project_name)
     python3 -c "
 import json, sys
 try:
+    mode = sys.argv[4]
     with open(sys.argv[1]) as f:
         cfg = json.load(f)
     sess = cfg['projects'][sys.argv[2]]['sessions'][sys.argv[3]]
@@ -438,33 +443,116 @@ try:
         sys.exit(0)
     active = sess.get('active')
     for h in sess['history']:
+        is_archived = h.get('archived', False)
+        if mode != 'all' and is_archived:
+            continue
         sid = h.get('session_id', '')
         marker = '*' if sid == active else ''
         iss = h.get('issue')
-        print(sid + '\t' + h['name'] + '\t' + (str(iss) if iss is not None else '') + '\t' + (h.get('created') or '') + '\t' + marker)
+        arch = 'archived' if is_archived else ''
+        print(sid + '\t' + h['name'] + '\t' + (str(iss) if iss is not None else '') + '\t' + (h.get('created') or '') + '\t' + marker + '\t' + arch)
 except (KeyError, TypeError, FileNotFoundError, json.JSONDecodeError):
     pass
-" "$FORGE_CONFIG_DIR/config.json" "$project_name" "$role" 2>/dev/null || true
+" "$FORGE_CONFIG_DIR/config.json" "$project_name" "$role" "$mode" 2>/dev/null || true
+}
+
+# archive_closed_sessions — mark sessions for closed issues as archived.
+# Usage: archive_closed_sessions <agent_role>
+# For each non-archived session with an issue number, checks if the issue is
+# closed via `gh issue view`. If closed, sets archived=true and clears active
+# if it was the active session. Non-blocking: if gh fails, the session is kept.
+archive_closed_sessions() {
+    local role="$1"
+    local project_name
+    project_name=$(_forge_project_name)
+
+    # Collect issue numbers from non-archived sessions
+    local issues_to_check=()
+    while IFS=$'\t' read -r sid name iss dt marker _archived; do
+        [ -z "$sid" ] && continue
+        [ -z "$iss" ] && continue
+        issues_to_check+=("$iss")
+    done < <(list_sessions "$role")
+
+    # No sessions with issues — nothing to check
+    [ ${#issues_to_check[@]} -eq 0 ] && return 0
+
+    # Deduplicate
+    local unique_issues
+    unique_issues=$(printf '%s\n' "${issues_to_check[@]}" | sort -u)
+
+    # Check each issue — collect closed ones
+    local closed_issues=()
+    for iss in $unique_issues; do
+        local state
+        state=$(gh issue view "$iss" --json state --jq '.state' 2>/dev/null) || continue
+        if [ "$state" = "CLOSED" ]; then
+            closed_issues+=("$iss")
+        fi
+    done
+
+    # Nothing to archive
+    [ ${#closed_issues[@]} -eq 0 ] && return 0
+
+    # Mark sessions as archived in config
+    local closed_json
+    closed_json=$(printf '%s\n' "${closed_issues[@]}" | python3 -c "import sys,json; print(json.dumps([int(l.strip()) for l in sys.stdin if l.strip()]))")
+    python3 -c "
+import json, sys
+cfg_path, proj, role = sys.argv[1], sys.argv[2], sys.argv[3]
+closed = json.loads(sys.argv[4])
+try:
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+except json.JSONDecodeError as e:
+    print(f'Error: {cfg_path} is corrupted: {e}', file=sys.stderr)
+    sys.exit(1)
+sess = cfg.get('projects', {}).get(proj, {}).get('sessions', {}).get(role)
+if not isinstance(sess, dict):
+    sys.exit(0)
+changed = False
+for h in sess.get('history', []):
+    iss = h.get('issue')
+    if iss is not None and iss in closed and not h.get('archived', False):
+        h['archived'] = True
+        changed = True
+        # Clear active if this was the active session
+        if sess.get('active') == h.get('session_id'):
+            sess['active'] = None
+if changed:
+    with open(cfg_path, 'w') as f:
+        json.dump(cfg, f, indent=2)
+        f.write('\n')
+" "$FORGE_CONFIG_DIR/config.json" "$project_name" "$role" "$closed_json"
 }
 
 # pick_session — interactive session picker with arrow keys and number input.
-# Usage: pick_session <agent_role>
+# Usage: pick_session <agent_role> [mode]
+# mode: "all" = show all sessions including archived (for sessions command),
+#       default = prune closed issues first, show only non-archived.
 # Prints the chosen session_id (UUID) to stdout. Empty if user chooses "start fresh."
 # Skips the picker and returns empty if no history exists.
 pick_session() {
     local role="$1"
+    local mode="${2:-}"
     local sessions=()
-    local names=() issues=() dates=() markers=()
+    local names=() issues=() dates=() markers=() archived_flags=()
+
+    # Auto-prune closed-issue sessions before showing (unless browsing all)
+    if [ "$mode" != "all" ]; then
+        archive_closed_sessions "$role"
+    fi
 
     # Read session history
-    while IFS=$'\t' read -r sid name iss dt marker; do
+    while IFS=$'\t' read -r sid name iss dt marker arch; do
         [ -z "$sid" ] && continue
         sessions+=("$sid")
         names+=("$name")
         issues+=("$iss")
         dates+=("$dt")
         markers+=("$marker")
-    done < <(list_sessions "$role")
+        archived_flags+=("$arch")
+    done < <(list_sessions "$role" "$mode")
 
     # No history — return empty (start fresh)
     if [ ${#sessions[@]} -eq 0 ]; then
@@ -504,6 +592,9 @@ pick_session() {
             fi
             if [ "${markers[$i]}" = "*" ]; then
                 suffix="${suffix} [active]"
+            fi
+            if [ "${archived_flags[$i]}" = "archived" ]; then
+                suffix="${suffix} [archived]"
             fi
             printf "  %s %d. %s%s\n" "$prefix" "$((i + 1))" "${names[$i]}" "$suffix" >&2
             line_count=$((line_count + 1))

--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -66,6 +66,7 @@ show_usage() {
     echo "  cast             Full autonomous cycle: smelt → stoke → hone"
     echo ""
     echo "  Prefix 'auto-' for autonomous mode (e.g., forge auto-smelt)."
+    echo "  Append 'sessions' to browse session history (e.g., forge hammer sessions)."
     echo ""
     echo "Operations:"
     echo "  deploy           Deploy main to production (human only)"
@@ -200,6 +201,17 @@ show_command_help() {
             echo "  Audit        No bugs — technical + UX/design audit against GRADING_CRITERIA.md"
             echo ""
             echo "The CLI detects which role to use based on project state."
+            ;;
+        sessions)
+            echo "forge <command> sessions — Browse session history"
+            echo ""
+            echo "Usage: forge smelt sessions"
+            echo "       forge hammer sessions"
+            echo "       forge temper sessions"
+            echo "       forge hone sessions"
+            echo ""
+            echo "Shows all sessions (including archived) for the given agent."
+            echo "Select any session to resume it."
             ;;
         stoke)
             echo "forge stoke — Autonomously process the issue queue"
@@ -543,6 +555,21 @@ case "${1:-}" in
     smelt|auto-smelt)
         FORGE_COMMAND="$1"; shift
 
+        if [ "${1:-}" = "sessions" ]; then
+            require_forge_project
+            local sess_choice
+            sess_choice=$(pick_session "smelter" "all")
+            if [ -n "$sess_choice" ]; then
+                local sess_agent
+                sess_agent=$(_resolve_smelter_agent "interactive")
+                agent_msg SMELTER "Resuming session..."
+                run_forge_agent "$sess_agent" "Continue where you left off." "" --resume-session "$sess_choice" --interactive
+            else
+                forge_info "No session selected."
+            fi
+            exit 0
+        fi
+
         require_forge_project
         check_auth
         check_labels
@@ -624,6 +651,19 @@ case "${1:-}" in
     hammer|auto-hammer)
         FORGE_COMMAND="$1"; shift
 
+        if [ "${1:-}" = "sessions" ]; then
+            require_forge_project
+            local sess_choice
+            sess_choice=$(pick_session "blacksmith" "all")
+            if [ -n "$sess_choice" ]; then
+                agent_msg BLACKSMITH "Resuming session..."
+                run_forge_agent "Blacksmith" "Continue where you left off." "" --resume-session "$sess_choice" --interactive
+            else
+                forge_info "No session selected."
+            fi
+            exit 0
+        fi
+
         require_forge_project
         check_auth
         check_labels
@@ -681,6 +721,19 @@ case "${1:-}" in
     temper|auto-temper)
         FORGE_COMMAND="$1"; shift
 
+        if [ "${1:-}" = "sessions" ]; then
+            require_forge_project
+            local sess_choice
+            sess_choice=$(pick_session "temperer" "all")
+            if [ -n "$sess_choice" ]; then
+                agent_msg TEMPERER "Resuming session..."
+                run_forge_agent "Temperer" "Continue where you left off." "" --resume-session "$sess_choice" --interactive
+            else
+                forge_info "No session selected."
+            fi
+            exit 0
+        fi
+
         require_forge_project
         check_auth
         check_labels
@@ -737,6 +790,21 @@ case "${1:-}" in
 
     hone|auto-hone)
         FORGE_COMMAND="$1"; shift
+
+        if [ "${1:-}" = "sessions" ]; then
+            require_forge_project
+            local sess_choice
+            sess_choice=$(pick_session "honer" "all")
+            if [ -n "$sess_choice" ]; then
+                local sess_agent
+                sess_agent=$(_resolve_honer_agent "interactive")
+                agent_msg HONER "Resuming session..."
+                run_forge_agent "$sess_agent" "Continue where you left off." "" --resume-session "$sess_choice" --interactive
+            else
+                forge_info "No session selected."
+            fi
+            exit 0
+        fi
 
         require_forge_project
         check_auth

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -1029,3 +1029,217 @@ EOF
     [[ "$output" == *"Hammering issue #10"* ]]
     [[ "$output" != *"--resume"* ]]
 }
+
+# --- session archiving ---
+
+@test "archive_closed_sessions marks sessions for closed issues" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    set_session "blacksmith" "blacksmith-issue-10" "aaaaaaaa-1111-2222-3333-444444444444" "10"
+    set_session "blacksmith" "blacksmith-issue-11" "bbbbbbbb-2222-3333-4444-555555555555" "11"
+    # Mock gh: issue 10 is CLOSED, issue 11 is OPEN
+    mock_gh_with '
+        if [[ "$*" == *"issue view"* ]] && [[ "$*" == *"10"* ]]; then
+            echo "CLOSED"
+            exit 0
+        fi
+        if [[ "$*" == *"issue view"* ]] && [[ "$*" == *"11"* ]]; then
+            echo "OPEN"
+            exit 0
+        fi
+    '
+    archive_closed_sessions "blacksmith"
+    # Issue 10 session should be archived, issue 11 should not
+    run list_sessions "blacksmith" "all"
+    [[ "$output" == *"aaaaaaaa-1111-2222-3333-444444444444"*"archived"* ]]
+    [[ "$output" == *"bbbbbbbb-2222-3333-4444-555555555555"* ]]
+    # Non-all list should exclude archived
+    run list_sessions "blacksmith"
+    [[ "$output" != *"aaaaaaaa-1111-2222-3333-444444444444"* ]]
+    [[ "$output" == *"bbbbbbbb-2222-3333-4444-555555555555"* ]]
+}
+
+@test "archive_closed_sessions clears active if archived session was active" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    set_session "blacksmith" "blacksmith-issue-10" "aaaaaaaa-1111-2222-3333-444444444444" "10"
+    mock_gh_with '
+        if [[ "$*" == *"issue view"* ]]; then
+            echo "CLOSED"
+            exit 0
+        fi
+    '
+    archive_closed_sessions "blacksmith"
+    # Active session should be cleared because it was archived
+    run get_session "blacksmith"
+    [[ -z "$output" ]]
+}
+
+@test "archive_closed_sessions is non-blocking on gh failure" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    set_session "blacksmith" "blacksmith-issue-10" "aaaaaaaa-1111-2222-3333-444444444444" "10"
+    # Mock gh to fail (network error)
+    mock_gh_with 'exit 1'
+    archive_closed_sessions "blacksmith"
+    # Session should NOT be archived when gh fails
+    run list_sessions "blacksmith"
+    [[ "$output" == *"aaaaaaaa-1111-2222-3333-444444444444"* ]]
+}
+
+@test "get_session skips archived sessions" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {
+        "blacksmith": {
+          "active": "aaaaaaaa-1111-2222-3333-444444444444",
+          "history": [
+            {
+              "name": "blacksmith-issue-10",
+              "session_id": "aaaaaaaa-1111-2222-3333-444444444444",
+              "issue": 10,
+              "created": "2026-01-01T00:00:00Z",
+              "archived": true
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    run get_session "blacksmith"
+    [[ "$status" -eq 0 ]]
+    [[ -z "$output" ]]
+}
+
+@test "list_sessions default mode excludes archived" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {
+        "blacksmith": {
+          "active": null,
+          "history": [
+            {
+              "name": "blacksmith-issue-10",
+              "session_id": "aaaaaaaa-1111-2222-3333-444444444444",
+              "issue": 10,
+              "created": "2026-01-01T00:00:00Z",
+              "archived": true
+            },
+            {
+              "name": "blacksmith-issue-11",
+              "session_id": "bbbbbbbb-2222-3333-4444-555555555555",
+              "issue": 11,
+              "created": "2026-01-02T00:00:00Z"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    run list_sessions "blacksmith"
+    [[ "$output" != *"aaaaaaaa-1111-2222-3333-444444444444"* ]]
+    [[ "$output" == *"bbbbbbbb-2222-3333-4444-555555555555"* ]]
+}
+
+@test "list_sessions all mode includes archived with marker" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {
+        "blacksmith": {
+          "active": null,
+          "history": [
+            {
+              "name": "blacksmith-issue-10",
+              "session_id": "aaaaaaaa-1111-2222-3333-444444444444",
+              "issue": 10,
+              "created": "2026-01-01T00:00:00Z",
+              "archived": true
+            },
+            {
+              "name": "blacksmith-issue-11",
+              "session_id": "bbbbbbbb-2222-3333-4444-555555555555",
+              "issue": 11,
+              "created": "2026-01-02T00:00:00Z"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    run list_sessions "blacksmith" "all"
+    [[ "$output" == *"aaaaaaaa-1111-2222-3333-444444444444"*"archived"* ]]
+    [[ "$output" == *"bbbbbbbb-2222-3333-4444-555555555555"* ]]
+}
+
+@test "archive_closed_sessions skips sessions without issue numbers" {
+    mkdir -p "$FORGE_CONFIG_DIR"
+    cat > "$FORGE_CONFIG_DIR/config.json" <<EOF
+{
+  "projects": {
+    "$(basename "$TEST_TMPDIR")": {
+      "path": "$TEST_TMPDIR",
+      "sessions": {}
+    }
+  }
+}
+EOF
+    cd "$TEST_TMPDIR"
+    set_session "smelter" "smelter-ingot" "aaaaaaaa-1111-2222-3333-444444444444" ""
+    # Mock gh should not even be called
+    mock_gh_with 'echo "SHOULD_NOT_BE_CALLED"; exit 1'
+    archive_closed_sessions "smelter"
+    # Session should remain unchanged
+    run list_sessions "smelter"
+    [[ "$output" == *"smelter-ingot"* ]]
+}


### PR DESCRIPTION
## Summary
- **Auto-prune**: `pick_session` now calls `archive_closed_sessions` before displaying, which checks each session's linked issue via `gh issue view` and marks closed ones as archived. The normal picker only shows sessions for open issues.
- **`forge <cmd> sessions`**: New subcommand (`forge smelt sessions`, `forge hammer sessions`, `forge temper sessions`, `forge hone sessions`) to browse ALL session history including archived. Users can select any session to resume.
- **Headless respect**: `get_session` skips archived sessions so auto/stoke/cast never resume stale work for closed issues.

### Storage model
Session history entries gain an optional `archived: true` field. Existing entries without the field are treated as non-archived (backward compatible).

### Key design decisions
- Archiving preserves session data (not deleted) — sessions remain retrievable via `sessions` subcommand
- `gh issue view` checks are non-blocking: if gh fails (network), sessions are kept as-is
- `list_sessions` accepts a `mode` parameter: default excludes archived, `"all"` includes them
- `pick_session` accepts a `mode` parameter: default prunes first, `"all"` shows everything

Closes #297

## Test plan
- [x] All 73 tests pass (66 existing + 7 new)
- [x] `archive_closed_sessions` marks sessions for closed issues
- [x] `archive_closed_sessions` clears active if archived session was active
- [x] `archive_closed_sessions` is non-blocking on gh failure
- [x] `get_session` skips archived sessions
- [x] `list_sessions` default mode excludes archived
- [x] `list_sessions` all mode includes archived with marker
- [x] `archive_closed_sessions` skips sessions without issue numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)