### PR TITLE
Ban all background agents and add version consistency test

### DIFF
--- a/plugin/agents/auto-blacksmith.md
+++ b/plugin/agents/auto-blacksmith.md
@@ -25,7 +25,7 @@ Implement the current issue end-to-end: research, plan, code, test, self-review,
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 
@@ -166,7 +166,7 @@ Review `README.md` and update it to reflect any changes from this implementation
 
 ### 9. Self-Review
 
-Review your own diff (`git diff main...HEAD`). Launch review agents in parallel for targeted analysis:
+Review your own diff (`git diff main...HEAD`). Launch all three review agents in a single foreground message — do not skip any, and never use `run_in_background`:
 
 - **`pr-review-toolkit:code-reviewer`** — Bugs, logic errors, code quality issues
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling

--- a/plugin/agents/auto-honer-audit.md
+++ b/plugin/agents/auto-honer-audit.md
@@ -24,7 +24,7 @@ Audit the codebase and the running application. Evaluate technical quality and U
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/auto-honer.md
+++ b/plugin/agents/auto-honer.md
@@ -23,7 +23,7 @@ Investigate the provided bug issue, validate it against the codebase, research c
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/auto-smelter-feature.md
+++ b/plugin/agents/auto-smelter-feature.md
@@ -27,7 +27,7 @@ Your job is to envision, not just transcribe. When processing a feature request,
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/auto-smelter.md
+++ b/plugin/agents/auto-smelter.md
@@ -28,7 +28,7 @@ Your job is to envision, not just transcribe. When processing a feature request,
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/auto-temperer.md
+++ b/plugin/agents/auto-temperer.md
@@ -21,7 +21,7 @@ Independently evaluate the current implementation. If approved, open a PR and me
 
 ## Agent execution rule
 
-**Never launch research or review agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -25,7 +25,7 @@ Implement the current issue end-to-end, conferring with the user on approach bef
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 
@@ -189,7 +189,7 @@ Review `README.md` and update it to reflect any changes from this implementation
 
 ### 10. Self-Review
 
-Review your own diff (`git diff main...HEAD`). Launch review agents in parallel for targeted analysis:
+Review your own diff (`git diff main...HEAD`). Launch all three review agents in a single foreground message — do not skip any, and never use `run_in_background`:
 
 - **`pr-review-toolkit:code-reviewer`** — Bugs, logic errors, code quality issues
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling

--- a/plugin/agents/honer-audit.md
+++ b/plugin/agents/honer-audit.md
@@ -24,7 +24,7 @@ Work with the user to audit the codebase and the running application. Evaluate t
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/honer.md
+++ b/plugin/agents/honer.md
@@ -23,7 +23,7 @@ Work with the user to triage a human-filed bug. Investigate the root cause, vali
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/smelter-feature.md
+++ b/plugin/agents/smelter-feature.md
@@ -27,7 +27,7 @@ Dream big. Your job is to envision, not just transcribe. When a user describes a
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/smelter.md
+++ b/plugin/agents/smelter.md
@@ -28,7 +28,7 @@ Dream big. Your job is to envision, not just transcribe. When a user describes w
 
 ## Agent execution rule
 
-**Never launch research or planning agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/plugin/agents/temperer.md
+++ b/plugin/agents/temperer.md
@@ -21,7 +21,7 @@ Independently evaluate the current implementation, confer with the user on findi
 
 ## Agent execution rule
 
-**Never launch research or review agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
+**Never launch agents with `run_in_background: true`.** All agents must run in the foreground so their results are available before proceeding. "In parallel" means multiple foreground agent calls in a single message — not background execution. Do not advance to the next step until every launched agent has returned its results.
 
 ## Issue Ownership
 

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -1584,3 +1584,31 @@ EOF
     run list_sessions "smelter"
     [[ "$output" == *"smelter-ingot"* ]]
 }
+
+# --- version consistency ---
+#
+# All version files must agree. A partial bump (e.g., forgetting to update
+# marketplace.json) would ship silently with no test failure. This test
+# catches the drift. (Filed as #312.)
+
+@test "version strings are consistent across plugin.json, marketplace.json, and CHANGELOG" {
+    ensure_jq
+
+    local plugin_ver marketplace_meta_ver marketplace_plugin_ver changelog_ver
+
+    plugin_ver=$(jq -r '.version' "$FORGE_TEST_DIR/plugin/.claude-plugin/plugin.json")
+    marketplace_meta_ver=$(jq -r '.metadata.version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json")
+    marketplace_plugin_ver=$(jq -r '.plugins[0].version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json")
+    changelog_ver=$(grep -m1 '^## \[' "$FORGE_TEST_DIR/CHANGELOG.md" | sed 's/^## \[\([^]]*\)\].*/\1/')
+
+    # All four must be non-empty
+    [[ -n "$plugin_ver" ]]
+    [[ -n "$marketplace_meta_ver" ]]
+    [[ -n "$marketplace_plugin_ver" ]]
+    [[ -n "$changelog_ver" ]]
+
+    # All four must match
+    [[ "$plugin_ver" == "$marketplace_meta_ver" ]]
+    [[ "$plugin_ver" == "$marketplace_plugin_ver" ]]
+    [[ "$plugin_ver" == "$changelog_ver" ]]
+}

--- a/tests/cli/forge_lib.bats
+++ b/tests/cli/forge_lib.bats
@@ -1596,15 +1596,21 @@ EOF
 
     local plugin_ver marketplace_meta_ver marketplace_plugin_ver changelog_ver
 
-    plugin_ver=$(jq -r '.version' "$FORGE_TEST_DIR/plugin/.claude-plugin/plugin.json")
-    marketplace_meta_ver=$(jq -r '.metadata.version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json")
-    marketplace_plugin_ver=$(jq -r '.plugins[0].version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json")
-    changelog_ver=$(grep -m1 '^## \[' "$FORGE_TEST_DIR/CHANGELOG.md" | sed 's/^## \[\([^]]*\)\].*/\1/')
+    # Use jq -er so missing keys exit non-zero instead of printing "null"
+    run jq -er '.version' "$FORGE_TEST_DIR/plugin/.claude-plugin/plugin.json"
+    [[ "$status" -eq 0 ]]
+    plugin_ver="$output"
 
-    # All four must be non-empty
-    [[ -n "$plugin_ver" ]]
-    [[ -n "$marketplace_meta_ver" ]]
-    [[ -n "$marketplace_plugin_ver" ]]
+    run jq -er '.metadata.version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json"
+    [[ "$status" -eq 0 ]]
+    marketplace_meta_ver="$output"
+
+    run jq -er '.plugins[0].version' "$FORGE_TEST_DIR/.claude-plugin/marketplace.json"
+    [[ "$status" -eq 0 ]]
+    marketplace_plugin_ver="$output"
+
+    # Filter to semver headings (X.Y.Z) to avoid matching [Unreleased] or similar
+    changelog_ver=$(grep -E -m1 '^## \[[0-9]+\.[0-9]+\.[0-9]+' "$FORGE_TEST_DIR/CHANGELOG.md" | sed 's/^## \[\([^]]*\)\].*/\1/')
     [[ -n "$changelog_ver" ]]
 
     # All four must match


### PR DESCRIPTION
## Summary

Two issues resolved in one branch:

**#316 — Agent execution rule loophole:** The "Never launch" rule in all 12 craftsman agent files qualified which agents the ban covered — 10 said "research or planning" and 2 said "research or review." This left a loophole: review agents (`pr-review-toolkit:*`) aren't "research or planning" agents, so the Blacksmith backgrounded them during self-review, proceeded to post the ledger and transition labels while they were still running, and skipped `pr-test-analyzer` entirely. Fix: remove the qualifier so the rule covers ALL agents. Also strengthened the Blacksmith self-review step to explicitly say "all three review agents in a single foreground message — do not skip any."

**#312 — Version consistency test:** Added a bats test that asserts `plugin/.claude-plugin/plugin.json`, both version entries in `.claude-plugin/marketplace.json`, and the latest `CHANGELOG.md` heading all carry the same version string. Catches partial version bumps that would otherwise ship silently.

Closes #316
Closes #312

## Test plan

- [x] `bats tests/cli/forge_lib.bats` — 98/98 pass
- [x] `grep -r "research or planning" plugin/agents/` returns nothing
- [x] `grep -r "research or review" plugin/agents/` returns nothing
- [x] `grep -r "Never launch" plugin/agents/` shows unified wording across all 12 files
- [x] Self-review step in both Blacksmith variants says "all three review agents in a single foreground message"
- [x] Version consistency test passes against current manifests + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)