### PR TITLE
Fix forge deploy to handle production branch divergence

### DIFF
--- a/bin/forge.sh
+++ b/bin/forge.sh
@@ -1197,11 +1197,6 @@ with open(cfg_path, 'w') as f:
             exit 0
         fi
 
-        if ! git merge-base --is-ancestor origin/production origin/main; then
-            echo -e "${RED}Error:${NC} production has diverged from main. Resolve manually."
-            exit 1
-        fi
-
         # Show what's being deployed
         echo ""
         echo "Commits to deploy:"
@@ -1215,7 +1210,12 @@ with open(cfg_path, 'w') as f:
             exit 0
         fi
 
-        git push origin origin/main:refs/heads/production
+        # --force-with-lease: production is solely a deployment trigger and
+        # should always mirror main after deploy. Force is needed when
+        # production has diverged (e.g., an initial setup artifact). The
+        # lease check guards against a concurrent push to production between
+        # our fetch and this push.
+        git push --force-with-lease origin origin/main:refs/heads/production
         echo -e "${GREEN}Production updated. Vercel will deploy automatically.${NC}"
         ;;
 


### PR DESCRIPTION
## Summary

`forge deploy` hard-errored when the `production` branch had diverged from `main` ("production has diverged from main. Resolve manually."). Since production is solely a Vercel deployment trigger — never directly committed to — there's no reason to refuse. Removed the `merge-base --is-ancestor` check and switched the push to `--force-with-lease` so production always mirrors main after deploy, regardless of divergence from setup artifacts.

Closes #319

## Test plan

- [x] `bats tests/cli/forge_lib.bats` — 98/98 pass
- [x] `shellcheck -S warning bin/forge.sh` — clean
- [ ] Manual: `forge deploy` on a project where production has diverged from main — should show commits and deploy successfully after confirmation
- [ ] Manual: `forge deploy` when production is behind main (normal case) — unchanged behavior
- [ ] Manual: `forge deploy` when production equals main — still prints "Nothing to deploy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)