### PR TITLE
feat(agents): confer on self-review findings before fixing

### DIFF
--- a/plugin/agents/blacksmith.md
+++ b/plugin/agents/blacksmith.md
@@ -154,7 +154,18 @@ Review your own diff (`git diff main...HEAD`). Launch all three review agents in
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling
 - **`pr-review-toolkit:pr-test-analyzer`** — Test coverage gaps and quality
 
-Fix any issues found, then run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+A finding is any concern raised by any of the three agents, regardless of severity — nits, informational notes, and suggestions all count. If in doubt, confer.
+
+If all three agents return zero findings, skip straight to running **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+
+Otherwise, **confer with the user before fixing anything.** Present findings grouped by agent. For each finding propose a disposition with a one-sentence rationale:
+
+- **Fix** — you'll address it in this pass
+- **Reject** — false positive or disagreement; explain why
+
+Iterate based on user feedback. **Get explicit user confirmation on the dispositions before proceeding.**
+
+Then fix every **Fix** item and run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
 
 The goal is to catch your own mistakes before the code moves to review.
 

--- a/plugin/agents/rework-blacksmith.md
+++ b/plugin/agents/rework-blacksmith.md
@@ -164,7 +164,18 @@ Review your own diff (`git diff main...HEAD`). Launch all three review agents in
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling
 - **`pr-review-toolkit:pr-test-analyzer`** — Test coverage gaps and quality
 
-Fix any issues found, then run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+A finding is any concern raised by any of the three agents, regardless of severity — nits, informational notes, and suggestions all count. If in doubt, confer.
+
+If all three agents return zero findings, skip straight to running **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+
+Otherwise, **confer with the user before fixing anything.** Present findings grouped by agent. For each finding propose a disposition with a one-sentence rationale:
+
+- **Fix** — you'll address it in this pass
+- **Reject** — false positive or disagreement; explain why
+
+Iterate based on user feedback. **Get explicit user confirmation on the dispositions before proceeding.**
+
+Then fix every **Fix** item and run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
 
 ### 9. Address Rework Comments
 

--- a/plugin/agents/workshop-blacksmith.md
+++ b/plugin/agents/workshop-blacksmith.md
@@ -164,7 +164,18 @@ Review your own diff (`git diff main...HEAD`). Launch all three review agents in
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling
 - **`pr-review-toolkit:pr-test-analyzer`** — Test coverage gaps and quality
 
-Fix any issues found, then run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+A finding is any concern raised by any of the three agents, regardless of severity — nits, informational notes, and suggestions all count. If in doubt, confer.
+
+If all three agents return zero findings, skip straight to running **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+
+Otherwise, **confer with the user before fixing anything.** Present findings grouped by agent. For each finding propose a disposition with a one-sentence rationale:
+
+- **Fix** — you'll address it in this pass
+- **Reject** — false positive or disagreement; explain why
+
+Iterate based on user feedback. **Get explicit user confirmation on the dispositions before proceeding.**
+
+Then fix every **Fix** item and run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
 
 The goal is to catch your own mistakes before the code moves to review. **Never skip self-review.** **Never open a PR yourself** — the Workshop-Temperer creates and merges the PR after approval.
 

--- a/plugin/agents/workshop-rework-blacksmith.md
+++ b/plugin/agents/workshop-rework-blacksmith.md
@@ -127,7 +127,18 @@ Review your own diff (`git diff main...HEAD`). Launch all three review agents in
 - **`pr-review-toolkit:silent-failure-hunter`** — Silent failures, swallowed errors, inadequate error handling
 - **`pr-review-toolkit:pr-test-analyzer`** — Test coverage gaps and quality
 
-Fix any issues found, then run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+A finding is any concern raised by any of the three agents, regardless of severity — nits, informational notes, and suggestions all count. If in doubt, confer.
+
+If all three agents return zero findings, skip straight to running **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
+
+Otherwise, **confer with the user before fixing anything.** Present findings grouped by agent. For each finding propose a disposition with a one-sentence rationale:
+
+- **Fix** — you'll address it in this pass
+- **Reject** — false positive or disagreement; explain why
+
+Iterate based on user feedback. **Get explicit user confirmation on the dispositions before proceeding.**
+
+Then fix every **Fix** item and run **`pr-review-toolkit:code-simplifier`** as a final cleanup pass.
 
 ### 8. Address Rework Comments
 


### PR DESCRIPTION
## Summary

All four interactive Blacksmith variants now present review-agent findings to the user with a binary **Fix** / **Reject** disposition and one-sentence rationale, then require explicit user confirmation before implementing any fixes. Auto variants (`auto-blacksmith`, `auto-rework-blacksmith`) are intentionally untouched — they keep silent-fix behavior since they have no user to confer with.

The Self-Review step also now explicitly defines what counts as a finding ("any concern raised by any of the three agents, regardless of severity"), so the agent can't rationalize skipping the confer gate when reviewers return nits or informational notes.

Closes #328

## Files changed

- `plugin/agents/blacksmith.md` (§8 Self-Review)
- `plugin/agents/rework-blacksmith.md` (§8 Self-Review)
- `plugin/agents/workshop-blacksmith.md` (§9 Self-Review)
- `plugin/agents/workshop-rework-blacksmith.md` (§7 Self-Review)

The inserted block is byte-identical across all four files; per-file trailers (e.g., workshop-blacksmith's "Never open a PR yourself" line) are preserved.

## Test plan

- [x] All 127 existing bats tests pass (`bats tests/cli/forge_lib.bats`)
- [x] Auto variants (`auto-blacksmith.md`, `auto-rework-blacksmith.md`) unchanged
- [x] Each interactive variant's Self-Review section preserves its surrounding structure and trailers
- [ ] Runtime validation: next `forge hammer` run exercises the confer step on real review findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)