### PR TITLE
Release v0.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "name": "Allan Mobley Jr."
   },
   "metadata": {
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "plugins": [
     {
       "name": "forge",
       "source": "./plugin",
       "description": "Autonomous Next.js development pipeline with craftsman agents",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "repository": "https://github.com/allan-mobley-jr/forge",
       "keywords": ["nextjs", "vercel", "autonomous", "agents", "development"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `forge deploy` for human-controlled production releases
 - `curl | bash` installer with Vercel plugin and Playwright MCP setup
 
+[0.8.1]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.8.1
 [0.8.0]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.8.0
 [0.7.0]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.7.0
 [0.6.3]: https://github.com/allan-mobley-jr/forge/releases/tag/v0.6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.1] - 2026-04-21
+
+### Changed
+- Interactive Blacksmith variants (Blacksmith, Rework-Blacksmith, Workshop-Blacksmith, Workshop-Rework-Blacksmith) now confer with the user before implementing self-review findings. The Blacksmith presents each finding from `code-reviewer`, `silent-failure-hunter`, and `pr-test-analyzer` with a proposed Fix/Reject disposition and requires explicit user confirmation before fixing. A finding is any concern raised by any of the three agents, regardless of severity. Auto variants keep their silent-fix behavior.
+
 ## [0.8.0] - 2026-04-20
 
 ### Added

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "forge",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Autonomous Next.js development pipeline with craftsman agents (Smelter, Blacksmith, Temperer, Honer)",
   "author": {
     "name": "Allan Mobley Jr."


### PR DESCRIPTION
## Release v0.8.1

### Changed
- Interactive Blacksmith variants (Blacksmith, Rework-Blacksmith, Workshop-Blacksmith, Workshop-Rework-Blacksmith) now confer with the user before implementing self-review findings. The Blacksmith presents each finding from `code-reviewer`, `silent-failure-hunter`, and `pr-test-analyzer` with a proposed Fix/Reject disposition and requires explicit user confirmation before fixing. A finding is any concern raised by any of the three agents, regardless of severity. Auto variants keep their silent-fix behavior.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)